### PR TITLE
feat: tile-organizer panel — drag tiles between visibility lanes

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -86,6 +86,100 @@ Open scope questions for triage:
 
 Leverage more of Claude Code's 27 hook event types. Partially done (v0.9.0 added multi-agent + error matchers, v0.9.1 added compaction + lifecycle, v0.9.3 added PostToolUse). Remaining opportunities: TaskCreated/TaskCompleted (show task progress count on tile).
 
+### Tile icons accept SVG file paths, not just codicon names
+**Requested:** 2026-05-09 (Matt)
+
+The `icon` field on a terminal entry currently only accepts codicon names (`types.ts:41` — `icon: string | null` documented as "codicon name"). The webview renders them via `codicon codicon-${name}` (`webview.js:195`). This means CLB's own activity-bar icon (`media/dashboard.svg`) can't be reused on the `claudelike-bar` *tile* — same extension, two icon systems.
+
+Want: support an SVG file path alternative so any extension-bundled or user-supplied SVG can be used as a tile icon. Detect by extension (`.svg`) or by leading `/` / `media/` prefix and route to a different render path.
+
+**Scope.**
+
+1. Type change: `icon: string | null` → `icon: string | null` with documented dual-meaning, OR a tagged shape like `icon: { codicon: string } | { svg: string }`. Lean on the first (string-with-detection) for back-compat — every existing config keeps working.
+2. Render path: in `webview.js`, when `tile.icon` ends in `.svg` or starts with `/`, render `<img src=${webview.asWebviewUri(file)}>` instead of the codicon span. Need to pipe the SVG file through `webview.asWebviewUri()` — the dashboard provider already has the webview reference, so resolution happens extension-side and the URI is sent to the webview pre-resolved.
+3. Security: only allow paths within `extensionPath/media/` and `~/.claude/icons/` (a new convention dir). Reject anything else to avoid accidentally exposing arbitrary filesystem reads via the webview.
+4. Color tinting: codicons inherit `currentColor`, so the existing per-tile color theming "just works." For SVG `<img>`, color doesn't bleed through. Either (a) require tile-icon SVGs to use `currentColor` and inline them as `<svg>` tags rather than `<img>` (small fetch-and-inline pass), or (b) accept that user-supplied SVGs render at their own colors and document it. Option (a) is more work but preserves the visual consistency — every other tile gets its color from the per-tile `color` field.
+
+**Effort estimate:** 30–45 min for the simple `<img>` version, +15 min for inline-SVG tinting. Tests: one for each new resolution path (codicon-name, .svg path, invalid path).
+
+**Concrete trigger:** the `claudelike-bar` tile in Matt's bar — it currently uses codicon `extensions` (puzzle piece) because the activity-bar icon at `media/dashboard.svg` isn't reusable. Closing the gap lets the tile match the activity-bar icon.
+
+### Audio enabled by default for fresh installs
+**Requested:** 2026-05-09 (Matt)
+
+Today, a fresh install ships with `audio.enabled: false` — users have to discover and flip it on to hear anything. Most users want a chime when Claude finishes a turn (it's the bar's whole differentiator over the built-in terminal). Flip the default so new installs come up with audio on, using the bundled `can-crack.mp3` for `turnDone`.
+
+**Current behavior:**
+- Runtime check at `configManager.ts:480`: `return this.config.audio?.enabled === true;` → `undefined` reads as `false`.
+- Config writer at `configManager.ts:892`: `enabled: rawAudio.enabled === true` → fresh writes `enabled: false`.
+- `freshAudioBlock` flag at `configManager.ts:886` already detects "user has never touched the audio block" — re-use this signal.
+
+**Proposed change:**
+- Define `DEFAULT_AUDIO_ENABLED = true` constant alongside `DEFAULT_TURN_DONE_SOUND` in `claudePaths.ts`.
+- `isAudioEnabled()` (line 480) → return `this.config.audio?.enabled !== false` (default true unless explicitly disabled).
+- `generateConfigText()` (line 892) → write `enabled: rawAudio.enabled !== false` for fresh blocks; honor explicit `false` when user has set it.
+- Existing users who've never touched `audio.enabled` will hear sound on next start. That's arguably the desired behavior (the chime is the feature) but worth a release note + minor version bump.
+
+**Effort estimate:** 5–10 min code change + 5 min release note. Tests: assert fresh-config audio is on; assert explicit `enabled: false` is honored.
+
+**Caveats:**
+- Behavior change for existing users — covered by release notes. Flipping a default ON is gentler than OFF; users who don't want audio just flip it back.
+- `can-crack.mp3` resolves from the bundled extension directory if absent in `~/.claude/sounds/`, so no missing-file edge case.
+- Volume default `DEFAULT_AUDIO_VOLUME = 0.6` and debounce `DEFAULT_AUDIO_DEBOUNCE_MS = 150` already sensible — no change needed.
+
+### Project-organizer panel — drag/drop tiles between visibility lanes
+**Requested:** 2026-05-09 (Matt)
+
+The bar accumulates tiles fast (currently 28 entries in `.claudelike-bar.jsonc`). Today, getting a project out of the bar means right-click → "Hide from bar"; getting it back means the command palette; pinning is a context menu toggle; reordering is drag-within-bar. Four interactions, three locations. Want a single management panel — a "kanban" view of all known tiles, sorted into lanes by their current `(pinned, hidden)` flag combo, with drag/drop to move between lanes and reorder within them.
+
+**Lanes** (mapping to existing flags — no new data primitives needed):
+
+| Lane | `pinned` | `hidden` | Today's behavior |
+|---|---|---|---|
+| Auto-sort | false | false | Status-driven order in bar (current default) |
+| Pinned | true | false | Fixed-order zone at bar bottom, drag-reorderable |
+| Closed but visible | false | false + project terminal not running | Same as Auto-sort lane today — tile shown, click to launch |
+| Closed and not visible | — | true | Hidden from bar; reachable via command palette only |
+
+Caveat: lanes 1 and 3 collapse to the same `(pinned: false, hidden: false)` config state — the difference between them is runtime (terminal alive vs not), not config. **Decision (2026-05-09, Matt):** treat "Closed but visible" as a *passive* lane — tiles auto-appear there when their terminal exits, and you can't drag *into* it. Dragging *out of* it to Pinned or Closed-and-not-visible flips a flag; dragging to Auto-sort launches the project. This avoids the "kill-by-drag" footgun where dragging would terminate a running terminal. Lane membership for `(false, false)` tiles is derived from `dashboardProvider` runtime state, not a new config field.
+
+**Scope.**
+
+What already exists in the codebase:
+
+- `pinned: boolean` flag (`configManager.ts:59`), `setPinned()` method (`configManager.ts:633`).
+- `hidden: boolean` flag (`configManager.ts:68`), `setHidden()` method (`configManager.ts:647`).
+- `order: number` field + `setOrder(orderedNames: string[])` for drag-reorder (`configManager.ts:661`).
+- "Hide from bar" right-click action (`webview.js:518`) and pin toggle (`webview.js:548`).
+- Drag-and-drop within the bar that flips `sortMode` to manual.
+
+What's needed:
+
+1. **New webview panel** — separate from the sidebar bar (sidebar is too narrow for 4 columns). Open via gear menu or command "Claudelike Bar: Organize Projects". Renders 4 vertical columns of tile-shaped cards.
+2. **Drop handler** that translates `(srcLane, dstLane, position)` into the right combination of `setPinned` / `setHidden` / `setOrder` calls atomically. ~30 lines in `configManager.ts`.
+3. **HTML5 native DnD or a tiny lib** (e.g. SortableJS, ~12 KB) for cross-column drag with drop placeholders. Native DnD works but the cross-column-with-position UX is finicky; SortableJS pays for itself here.
+4. **Live re-sync** — panel listens to the same config-file watcher the bar uses; if you tweak the JSONC by hand, the panel updates. Reuse `dashboardProvider`'s update mechanism.
+
+What's *not* in scope (worth deferring):
+
+- Bulk operations (multi-select drag) — start with single-tile DnD, add multi-select if the v1 doesn't feel fast enough.
+- Search/filter within the panel — at 28 tiles this is fine; revisit at 50+.
+- Editing tile color/icon/nickname inline — keep that in the existing right-click menu / config file. Panel is purely about lane membership and order.
+
+**Effort estimate:** 60-90 minutes of Claude time for v1.
+- Backend (`configManager` lane-move method + extension command + panel registration): ~20 min
+- Webview panel HTML/CSS skeleton: ~15 min
+- DnD wiring (SortableJS or native + drop targets): ~25 min
+- Live re-sync via existing config-watcher: ~10 min
+- Tests (lane-move atomicity, DnD message round-trip via `webview-syntax.test.ts` style): ~15 min
+
+Risk areas:
+- Atomic flag flips when crossing lanes — easy to leave a tile in a half-state if the user drags fast and the messages reorder. Mitigation: single `moveTile(name, lane, position)` API that does all flag changes inside one config write, not three separate `setPinned`/`setHidden`/`setOrder` round-trips.
+- Distinguishing "auto-sort" vs "closed but visible" if going with option 1 above — needs the panel to read live tile state from `dashboardProvider`, not just config. Minor coupling but worth it to avoid the schema bump.
+- VS Code webview reload on theme change wiping local DnD state — known annoyance in other panels; standard fix is to persist the panel state in `webview.state` API.
+
+**Open question:** sidebar webview vs editor-area webview panel? Editor-area has more room for a 4-column kanban; sidebar can host a vertical-stack version (2 columns × 2 stacks). Lean editor-area for a real kanban feel.
+
 ## Deferred Design Work
 
 ### Crash watchdog

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -38,6 +38,56 @@ Counter math from this window alone is balanced (5 Start / 6 Stop → floors at 
 
 ## Feature Requests
 
+### User-configurable focus hotkeys per tile
+**Requested:** 2026-05-09 (Matt)
+
+The `claudeDashboard.focusByName` and `claudeDashboard.focusSlot1..9` commands already exist (#18, shipped v0.16.5) and work — but binding them requires hand-editing `~/.config/Code/User/keybindings.json`, which most users won't do. Want a discoverable path: per-tile hotkey assignment from the config file or a right-click "Set hotkey…" action, plus default bindings out of the box for the slot variants.
+
+**Scope.**
+
+What already exists:
+- `claudeDashboard.focusSlot1..9` — focuses the Nth live tile in current sort order (`extension.ts:196–222`)
+- `claudeDashboard.focusByName` — focuses a tile by displayName / name / projectName, takes a string `args` value (`extension.ts:224–250`)
+- Both commands resolve the underlying `vscode.Terminal` via `tracker.getTerminalById` and call `term.show()`. No UI surface.
+
+What's needed:
+
+1. **Default keybindings for the slot commands.** Ship a `contributes.keybindings` block in `package.json` that binds `Ctrl+Alt+1..9` (Linux/Windows) / `Cmd+Alt+1..9` (macOS) to `focusSlot1..9`. These combos are mostly free — VS Code uses `Ctrl+1..9` for editor groups and `Ctrl+\`+1..9` for terminal switching, but `Ctrl+Alt+1..9` is unclaimed in default bindings as of 1.93. Users can override in their own keybindings.json if they conflict with another extension.
+2. **Per-tile hotkey config field.** Add an optional `hotkey: string` field to `TerminalConfig` (e.g. `"hotkey": "ctrl+alt+a"`). On config load, dynamically register a keybinding via `vscode.commands.executeCommand` + the `setContext` pattern, OR (simpler) maintain a generated keybindings.json snippet the user can copy. Discoverability beats elegance — even a "Copy hotkey JSON" action in the right-click menu is a win.
+3. **Right-click "Set hotkey…" action.** InputBox prompts for a key combo, validates against a small allowlist of safe modifier patterns (see below), writes to the tile's `hotkey` field. Activation reads all `hotkey` fields and registers them. On conflict (same hotkey on two tiles, or hotkey claimed by VS Code), surface a warning toast pointing the user to keybindings.json.
+4. **F-key option.** Plain `F1..F12` in VS Code are mostly reserved (F1=palette, F2=rename, F5=debug, F8=problems, etc.). Modifier+F-key is much safer: `Ctrl+F1..F12`, `Alt+F1..F12`, `Ctrl+Shift+F1..F12` are largely free. Document these as the recommended option for users with >9 tiles or who want non-numeric mnemonic mappings (e.g. F1=api, F2=belfry).
+
+**Modifier collision map** (VS Code 1.93 defaults):
+
+| Combo | Status |
+|---|---|
+| `Ctrl+1..9` | TAKEN — switch editor group |
+| `` Ctrl+`+1..9 `` | TAKEN — switch active terminal |
+| `Ctrl+Alt+1..9` | FREE on Linux/Win; some Mac debug bindings — recommended default |
+| `Ctrl+Shift+1..9` | mostly FREE |
+| `Alt+1..9` | FREE on Linux/Win; menu mnemonics on some platforms |
+| `F1..F12` (plain) | mostly TAKEN |
+| `Ctrl+F1..F12` | mostly FREE |
+| `Alt+F1..F12` | mostly FREE |
+| `Ctrl+Shift+F1..F12` | mostly FREE |
+
+**What's *not* in scope:**
+- Cross-window hotkey routing — focus stays within the current VS Code window. Multi-window users are on their own.
+- Chord shortcuts (e.g. `Ctrl+K Ctrl+1`) — interesting later but the per-tile UX gets harder to validate.
+- Hotkey for non-focus actions (kill, mark-done, etc.) — keep this scoped to the focus use case.
+
+**Effort estimate:** 30–60 minutes for v1.
+- Default `Ctrl+Alt+1..9` keybindings block in package.json: ~5 min
+- Per-tile `hotkey` field + dynamic registration on activation: ~20 min
+- "Set hotkey…" right-click action with validation: ~20 min
+- Docs + collision-map note in README: ~10 min
+
+Risk areas:
+- Dynamic keybinding registration in VS Code: there's no first-class API for this. Workarounds include shipping `when` clauses gated on a context key + maintaining a generated keybindings.json fragment, or simply emitting a "Paste this into your keybindings.json" toast. Pick the cheaper one for v1.
+- Hotkey conflicts that only manifest in specific workspaces (other extensions). Resolution path: document the override pattern (`-claudeDashboard.focusSlot1` to disable) rather than try to detect.
+
+**Open question:** validate `hotkey` strings against VS Code's accelerator grammar at write-time, or accept anything and let the keybinding registration fail silently? The latter is simpler but harder to debug. Lean validation — we already have a small allowlist of safe modifier patterns from the collision map above.
+
 ### Context menu: "Switch to auto sort"
 **Requested:** 2026-04-16 (Matt)
 

--- a/media/organizer.css
+++ b/media/organizer.css
@@ -1,0 +1,185 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-foreground);
+  background: var(--vscode-editor-background);
+  padding: 16px 20px 12px;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.organizer-header h1 {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.organizer-header .hint {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  margin-bottom: 14px;
+  line-height: 1.5;
+}
+
+.lanes {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(180px, 1fr));
+  gap: 12px;
+  flex: 1;
+  min-height: 0;
+}
+
+.lane {
+  display: flex;
+  flex-direction: column;
+  background: var(--vscode-sideBar-background, rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 4px;
+  min-height: 0;
+}
+
+.lane > header {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--vscode-editorGroupHeader-tabsBackground, transparent);
+}
+
+.lane-title {
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.lane-sub {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  line-height: 1.4;
+}
+
+.cards {
+  flex: 1;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+  min-height: 80px;
+}
+
+.cards.empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.cards .empty-msg {
+  color: var(--vscode-descriptionForeground);
+  font-size: 11px;
+  text-align: center;
+  padding: 12px 8px;
+  font-style: italic;
+  pointer-events: none;
+}
+
+/* Drop highlight on droppable lanes only. */
+.cards[data-droppable="true"].drag-over {
+  background: var(--vscode-list-dropBackground, rgba(100, 150, 255, 0.08));
+  outline: 1px dashed var(--vscode-focusBorder);
+  outline-offset: -2px;
+}
+
+/* The passive lane (closed-visible) gets a subtle "no-drop" cursor when
+   something is being dragged over it. We don't outline it — passive means
+   silent reject, not a flashy error. */
+.cards[data-droppable="false"].drag-over {
+  cursor: not-allowed;
+}
+
+.card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--vscode-editor-background);
+  border: 1px solid var(--vscode-panel-border);
+  border-left: 4px solid var(--card-color, var(--vscode-panel-border));
+  border-radius: 3px;
+  cursor: grab;
+  font-size: 12px;
+  user-select: none;
+  transition: background 0.12s ease, opacity 0.2s ease;
+}
+
+.card:hover {
+  background: var(--vscode-list-hoverBackground);
+}
+
+.card.dragging {
+  opacity: 0.35;
+  cursor: grabbing;
+}
+
+.card.drop-before {
+  box-shadow: 0 -2px 0 0 var(--vscode-focusBorder);
+}
+
+.card.drop-after {
+  box-shadow: 0 2px 0 0 var(--vscode-focusBorder);
+}
+
+.card .card-icon {
+  font-size: 13px;
+  color: var(--card-color);
+  width: 14px;
+  text-align: center;
+}
+
+.card .card-name {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card .shell-tag {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 8px;
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  text-transform: uppercase;
+}
+
+.organizer-footer {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.organizer-footer button {
+  padding: 4px 10px;
+  font-size: 11px;
+  color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+  background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+  border: none;
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.organizer-footer button:hover {
+  background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground));
+}
+
+.organizer-footer .status {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+}

--- a/media/organizer.js
+++ b/media/organizer.js
@@ -1,0 +1,288 @@
+// @ts-nocheck
+/* Tile-organizer panel — vanilla JS, native HTML5 drag/drop, no deps.
+   The webview owns the lane layout; on drop, we ship the full picture
+   (pinnedOrder, unpinnedNames, hiddenNames) back to the extension which
+   applies it atomically through ConfigManager.applyOrganizerLayout. */
+(function () {
+  const vscode = acquireVsCodeApi();
+
+  // Lane keys map to the data-lane attributes in organizer.html.
+  const LANE_KEYS = ['pinned', 'auto', 'closedVisible', 'hidden'];
+
+  // Whether each lane accepts drops. closedVisible is passive — tiles auto-
+  // appear there when their terminal exits and you can't drag into it.
+  const DROPPABLE = {
+    pinned: true,
+    auto: true,
+    closedVisible: false,
+    hidden: true,
+  };
+
+  let state = {
+    pinned: [],
+    auto: [],
+    closedVisible: [],
+    hidden: [],
+  };
+
+  let dragSrc = null; // { name, lane } of the card being dragged
+  // Element currently showing a drop-before/drop-after placeholder. Cached
+  // so dragover (60fps hot path) can clear the prior indicator with a
+  // single classList op instead of a document-wide querySelectorAll.
+  let currentDropTarget = null;
+  // Most recent organizer:state message arrived during a drag — applied in
+  // dragend so the in-flight drop isn't clobbered by a mid-drag rebuild.
+  let pendingState = null;
+
+  function laneEl(key) {
+    return document.querySelector(`.lane[data-lane="${key}"] .cards`);
+  }
+
+  function render() {
+    for (const key of LANE_KEYS) {
+      const container = laneEl(key);
+      if (!container) continue;
+      container.innerHTML = '';
+      const cards = state[key] || [];
+      if (cards.length === 0) {
+        container.classList.add('empty');
+        const empty = document.createElement('div');
+        empty.className = 'empty-msg';
+        empty.textContent = laneEmptyHint(key);
+        container.appendChild(empty);
+      } else {
+        container.classList.remove('empty');
+        for (const card of cards) {
+          container.appendChild(makeCardEl(card, key));
+        }
+      }
+    }
+  }
+
+  function laneEmptyHint(key) {
+    if (key === 'pinned') return 'Drag tiles here to pin them at the bar bottom.';
+    if (key === 'auto') return 'No running tiles — open a Claude terminal to populate.';
+    if (key === 'closedVisible') return 'No registered tiles waiting for launch.';
+    if (key === 'hidden') return 'Drag tiles here to hide them from the bar.';
+    return '';
+  }
+
+  function makeCardEl(card, lane) {
+    const el = document.createElement('div');
+    el.className = 'card';
+    el.draggable = true;
+    el.dataset.name = card.name;
+    el.dataset.lane = lane;
+    el.style.setProperty('--card-color', card.themeColor);
+
+    const icon = document.createElement('span');
+    icon.className = 'card-icon codicon';
+    if (card.icon) icon.classList.add(`codicon-${card.icon}`);
+    else icon.classList.add('codicon-terminal');
+    el.appendChild(icon);
+
+    const name = document.createElement('span');
+    name.className = 'card-name';
+    name.textContent = card.displayName;
+    name.title = card.name === card.displayName
+      ? card.name
+      : `${card.displayName} (${card.name})`;
+    el.appendChild(name);
+
+    if (card.isShell) {
+      const tag = document.createElement('span');
+      tag.className = 'shell-tag';
+      tag.textContent = 'shell';
+      el.appendChild(tag);
+    }
+
+    el.addEventListener('dragstart', (e) => {
+      dragSrc = { name: card.name, lane };
+      el.classList.add('dragging');
+      e.dataTransfer.effectAllowed = 'move';
+      // setData is required for drag to fire in some browsers/webviews.
+      try { e.dataTransfer.setData('text/plain', card.name); } catch (_) {}
+    });
+    el.addEventListener('dragend', () => {
+      el.classList.remove('dragging');
+      dragSrc = null;
+      // Cleanup any lingering placeholders.
+      if (currentDropTarget) {
+        currentDropTarget.classList.remove('drop-before', 'drop-after');
+        currentDropTarget = null;
+      }
+      document.querySelectorAll('.cards.drag-over')
+        .forEach((c) => c.classList.remove('drag-over'));
+      // Apply any state update that arrived during the drag — we deferred
+      // it so the dragged DOM node wouldn't get clobbered mid-gesture.
+      if (pendingState) {
+        const next = pendingState;
+        pendingState = null;
+        applyState(next);
+      }
+    });
+
+    // Within-lane reorder: card-level dragover marks before/after.
+    el.addEventListener('dragover', (e) => {
+      if (!dragSrc) return;
+      const targetLaneKey = el.dataset.lane;
+      if (!DROPPABLE[targetLaneKey]) return;
+      // Auto-sort lane has no persisted order — within-lane reorder is a
+      // no-op there, so don't draw the placeholder. Cross-lane drops still
+      // work via the lane-container dragover handler.
+      if (targetLaneKey === 'auto') return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      const rect = el.getBoundingClientRect();
+      const before = (e.clientY - rect.top) < rect.height / 2;
+      // Clear the prior indicator (if any) and mark this one. Single
+      // classList op per move beats a document-wide query at 60fps.
+      if (currentDropTarget && currentDropTarget !== el) {
+        currentDropTarget.classList.remove('drop-before', 'drop-after');
+      } else if (currentDropTarget === el) {
+        // Same target as last frame — only flip the before/after side if
+        // the cursor crossed the midline.
+        el.classList.remove('drop-before', 'drop-after');
+      }
+      el.classList.add(before ? 'drop-before' : 'drop-after');
+      currentDropTarget = el;
+    });
+    el.addEventListener('drop', (e) => {
+      if (!dragSrc) return;
+      const targetLaneKey = el.dataset.lane;
+      if (!DROPPABLE[targetLaneKey]) return;
+      if (targetLaneKey === 'auto') return; // fall through to lane-level drop
+      e.preventDefault();
+      e.stopPropagation();
+      const before = el.classList.contains('drop-before');
+      const targetName = el.dataset.name;
+      moveCard(dragSrc.name, dragSrc.lane, targetLaneKey, { relative: targetName, before });
+    });
+
+    return el;
+  }
+
+  // Lane-level drop handlers — for drops onto empty space inside a lane,
+  // and for lanes where intra-lane order isn't tracked (auto-sort).
+  function wireLaneContainers() {
+    for (const key of LANE_KEYS) {
+      const container = laneEl(key);
+      if (!container) continue;
+      container.addEventListener('dragover', (e) => {
+        if (!dragSrc) return;
+        if (!DROPPABLE[key]) {
+          // Visually flag the rejection but don't preventDefault — the drop
+          // will be ignored by the browser since we never accept it.
+          container.classList.add('drag-over');
+          return;
+        }
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        container.classList.add('drag-over');
+      });
+      container.addEventListener('dragleave', (e) => {
+        // Only clear when leaving the container (not when crossing into a
+        // child card). relatedTarget is the element we're entering.
+        if (e.relatedTarget && container.contains(e.relatedTarget)) return;
+        container.classList.remove('drag-over');
+      });
+      container.addEventListener('drop', (e) => {
+        if (!dragSrc) return;
+        container.classList.remove('drag-over');
+        if (!DROPPABLE[key]) return;
+        // If a child card already handled this drop, bail — its handler
+        // calls stopPropagation(). This branch covers empty-lane drops and
+        // drops past the last card in a lane.
+        e.preventDefault();
+        moveCard(dragSrc.name, dragSrc.lane, key, { append: true });
+      });
+    }
+  }
+
+  // Apply a move to the local state, then ship the full layout to the host.
+  function moveCard(name, srcLane, dstLane, position) {
+    if (!srcLane || !dstLane) return;
+    if (!DROPPABLE[dstLane]) return;
+    if (srcLane === dstLane && position && position.relative === name) return;
+
+    // Remove from source lane.
+    const srcArr = state[srcLane];
+    const idx = srcArr.findIndex((c) => c.name === name);
+    if (idx === -1) return;
+    const [card] = srcArr.splice(idx, 1);
+
+    // Apply card stamp changes for cross-lane moves so the immediate render
+    // reflects the new lane (e.g. shell tag still renders, color persists).
+    const dstArr = state[dstLane];
+    if (position && position.relative) {
+      const targetIdx = dstArr.findIndex((c) => c.name === position.relative);
+      const insertAt = targetIdx === -1
+        ? dstArr.length
+        : (position.before ? targetIdx : targetIdx + 1);
+      dstArr.splice(insertAt, 0, card);
+    } else {
+      dstArr.push(card);
+    }
+
+    render();
+    sendLayout();
+  }
+
+  function sendLayout() {
+    vscode.postMessage({
+      type: 'organizer:applyLayout',
+      pinnedOrder: state.pinned.map((c) => c.name),
+      // Auto-sort + closed-but-visible share config state — same flag combo,
+      // runtime liveness is the only difference. Send them as one list.
+      unpinnedNames: [...state.auto, ...state.closedVisible].map((c) => c.name),
+      hiddenNames: state.hidden.map((c) => c.name),
+    });
+    setStatus('Saved.', true);
+  }
+
+  function setStatus(text, transient) {
+    const el = document.getElementById('status');
+    if (!el) return;
+    el.textContent = text;
+    if (transient) {
+      setTimeout(() => {
+        if (el.textContent === text) el.textContent = '';
+      }, 1500);
+    }
+  }
+
+  // Footer button: open the JSONC config in an editor.
+  document.querySelector('button[data-action="openConfig"]')?.addEventListener('click', () => {
+    vscode.postMessage({ type: 'organizer:openConfig' });
+  });
+
+  function applyState(msg) {
+    state = {
+      pinned: Array.isArray(msg.lanes?.pinned) ? msg.lanes.pinned : [],
+      auto: Array.isArray(msg.lanes?.auto) ? msg.lanes.auto : [],
+      closedVisible: Array.isArray(msg.lanes?.closedVisible) ? msg.lanes.closedVisible : [],
+      hidden: Array.isArray(msg.lanes?.hidden) ? msg.lanes.hidden : [],
+    };
+    render();
+  }
+
+  window.addEventListener('message', (e) => {
+    const msg = e.data;
+    if (!msg || msg.type !== 'organizer:state') return;
+    // Defer rebuilds while the user has a card grabbed — innerHTML='' on
+    // the lane container would detach the dragged DOM node mid-gesture
+    // and silently abort the HTML5 drag operation. dragend applies the
+    // pending state once the drop completes.
+    if (dragSrc) {
+      pendingState = msg;
+      return;
+    }
+    applyState(msg);
+  });
+
+  wireLaneContainers();
+  // Render once with whatever's in the (initially empty) state, then ask for
+  // the real picture. Avoids a flash of stale empty lanes.
+  render();
+  vscode.postMessage({ type: 'organizer:requestState' });
+})();

--- a/media/webview.css
+++ b/media/webview.css
@@ -174,6 +174,16 @@ body {
   animation: ready-pulse 2s ease-in-out infinite;
 }
 
+/* v0.19 (#36) — burst pulse for ~3s after a ready transition. Faster
+   animation + glow so the just-finished tile is visually unmissable
+   while the audio chime fires in parallel. Class auto-clears via a
+   tracker-side timer. Doubled selector specificity wins over `.dot.ready`
+   regardless of declaration order. */
+.dot.ready.fresh {
+  animation: ready-pulse-fresh 0.6s ease-in-out 5;
+  box-shadow: 0 0 6px 2px var(--vscode-terminal-ansiCyan);
+}
+
 .dot.waiting {
   background: var(--vscode-terminal-ansiYellow);
   animation: blink 1s step-end infinite;
@@ -245,6 +255,14 @@ body {
 @keyframes ready-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }
+}
+
+/* v0.19 (#36) — sharper, brighter pulse for the 3s burst window after a
+   ready transition. Pairs scale + opacity for a noticeable "thump" that
+   peripheral vision picks up. */
+@keyframes ready-pulse-fresh {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(1.4); }
 }
 
 @keyframes blink {

--- a/media/webview.js
+++ b/media/webview.js
@@ -222,7 +222,11 @@ function patchTile(el, tile) {
       : (tile.status === 'registered' && tile.type === 'shell')
         ? 'shell'
         : tile.status;
-    dot.className = `dot ${dotClass}`;
+    // v0.19 (#36) — `fresh` decorates the cyan ready pulse for ~3s after
+    // a transition into ready so the just-finished tile is visually
+    // unmissable. Tracker clears the flag via a per-tile timer.
+    const fresh = tile.status === 'ready' && tile.freshlyReady ? ' fresh' : '';
+    dot.className = `dot ${dotClass}${fresh}`;
   }
 
   // Time
@@ -313,6 +317,8 @@ function createTileEl(tile, index) {
     : (tile.status === 'registered' && tile.type === 'shell')
       ? 'shell'
       : tile.status;
+  // v0.19 (#36) — fresh-ready burst class on initial render too.
+  const fresh = tile.status === 'ready' && tile.freshlyReady ? ' fresh' : '';
 
   const iconHtml = tile.icon
     ? `<span class="tile-icon codicon codicon-${escapeHtml(tile.icon)}"></span>`
@@ -326,7 +332,7 @@ function createTileEl(tile, index) {
 
   el.innerHTML = `
     <div class="tile-header">
-      <span class="dot ${dotClass}"></span>
+      <span class="dot ${dotClass}${fresh}"></span>
       ${iconHtml}
       <span class="tile-name">${escapeHtml(displayName)}</span>
       ${tile.status !== 'idle' ? `<span class="tile-time">${timeStr}</span>` : '<span class="tile-time"></span>'}
@@ -548,6 +554,20 @@ function showContextMenu(e, tileId) {
     vscode.postMessage({ type: 'setPinned', id: tileId, pinned: !isPinned });
   });
   menu.appendChild(pinItem);
+
+  // v0.19 (#34) — Copy a keybindings.json snippet for this tile so users
+  // can wire a focus hotkey without remembering the focusByName syntax.
+  // VS Code has no first-class API for dynamically registering keybindings
+  // from an extension, so the snippet-to-clipboard route is the path that
+  // works today. Skip on registered/synthetic tiles — they don't have a
+  // live VS Code terminal to focus, and their slug is the only reachable
+  // identity (no nickname-as-projectName until launched).
+  if (!isRegistered) {
+    const hotkeyItem = menuItem('⌨', 'Copy hotkey JSON…', () => {
+      vscode.postMessage({ type: 'copyHotkeyJson', id: tileId });
+    });
+    menu.appendChild(hotkeyItem);
+  }
 
   // v0.12 — Mute / Unmute audio + Launch another project. Both are
   // Claude-workflow items — skip them on shell tiles.

--- a/package.json
+++ b/package.json
@@ -191,6 +191,53 @@
         "category": "Claudelike Bar"
       }
     ],
+    "keybindings": [
+      {
+        "command": "claudeDashboard.focusSlot1",
+        "key": "ctrl+alt+1",
+        "mac": "cmd+alt+1"
+      },
+      {
+        "command": "claudeDashboard.focusSlot2",
+        "key": "ctrl+alt+2",
+        "mac": "cmd+alt+2"
+      },
+      {
+        "command": "claudeDashboard.focusSlot3",
+        "key": "ctrl+alt+3",
+        "mac": "cmd+alt+3"
+      },
+      {
+        "command": "claudeDashboard.focusSlot4",
+        "key": "ctrl+alt+4",
+        "mac": "cmd+alt+4"
+      },
+      {
+        "command": "claudeDashboard.focusSlot5",
+        "key": "ctrl+alt+5",
+        "mac": "cmd+alt+5"
+      },
+      {
+        "command": "claudeDashboard.focusSlot6",
+        "key": "ctrl+alt+6",
+        "mac": "cmd+alt+6"
+      },
+      {
+        "command": "claudeDashboard.focusSlot7",
+        "key": "ctrl+alt+7",
+        "mac": "cmd+alt+7"
+      },
+      {
+        "command": "claudeDashboard.focusSlot8",
+        "key": "ctrl+alt+8",
+        "mac": "cmd+alt+8"
+      },
+      {
+        "command": "claudeDashboard.focusSlot9",
+        "key": "ctrl+alt+9",
+        "mac": "cmd+alt+9"
+      }
+    ],
     "menus": {
       "view/title": [
         {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,12 @@
         "category": "Claudelike Bar"
       },
       {
+        "command": "claudeDashboard.organizeProjects",
+        "title": "Organize Projects",
+        "icon": "$(layout)",
+        "category": "Claudelike Bar"
+      },
+      {
         "command": "claudeDashboard.showHooks",
         "title": "Show Me the Hooks (open docs)",
         "category": "Claudelike Bar"
@@ -194,6 +200,11 @@
         },
         {
           "command": "claudeDashboard.registerProject",
+          "when": "view == claudeDashboard.mainView",
+          "group": "navigation"
+        },
+        {
+          "command": "claudeDashboard.organizeProjects",
           "when": "view == claudeDashboard.mainView",
           "group": "navigation"
         },

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -177,6 +177,11 @@ const DEFAULT_AUDIO_DEBOUNCE_MS = 150;
 const CONFIG_FILENAME = '.claudelike-bar.jsonc';
 const LEGACY_CONFIG_FILENAME = '.claudelike-bar.json';
 
+// Names that resolve to live prototype objects under bracket-notation
+// lookup. Filtered at any boundary that takes terminal names from a
+// webview/IPC source so writes can't pollute Object.prototype.
+const RESERVED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 const DEFAULT_LABELS: Record<string, string> = {
   idle: 'Idle',
   working: 'Working',
@@ -684,6 +689,74 @@ export class ConfigManager implements vscode.Disposable {
       if (entry) entry.order = index;
     });
     this.config.sortMode = 'manual';
+    this.scheduleSave();
+  }
+
+  /**
+   * v0.19 — atomic layout write from the tile-organizer panel. The webview
+   * owns the full lane-membership picture; this method just applies it in a
+   * single config write.
+   *
+   *   pinnedOrder    — names with `pinned: true`, in the panel's display order
+   *                    (translates to `order: 0..N-1` within the pinned zone)
+   *   unpinnedNames  — names with `pinned: false, hidden: false`. Covers both
+   *                    "Auto-sort" (running) and "Closed but visible" lanes,
+   *                    which share config state and only differ at runtime.
+   *                    Order isn't persisted — auto-sort is status-driven.
+   *   hiddenNames    — names with `hidden: true`. Order doesn't matter;
+   *                    these tiles don't appear in the bar at all.
+   *
+   * Names not present in any list keep their existing flags (defensive — the
+   * panel is supposed to enumerate everything, but a stale message from a
+   * cached webview shouldn't silently archive tiles).
+   */
+  applyOrganizerLayout(layout: {
+    pinnedOrder: string[];
+    unpinnedNames: string[];
+    hiddenNames: string[];
+  }): void {
+    // Reject reserved property names — the webview is shipped by the
+    // extension today, but bracket-notation lookups on `__proto__` /
+    // `constructor` / `prototype` would return live prototype objects and
+    // turn any future webview message-channel slip into a host-wide
+    // prototype-pollution gadget. Belt-and-braces with hasOwnProperty.call.
+    const lookup = (name: string): TerminalConfig | undefined => {
+      if (RESERVED_KEYS.has(name)) return undefined;
+      if (!Object.prototype.hasOwnProperty.call(this.config.terminals, name)) {
+        return undefined;
+      }
+      return this.config.terminals[name];
+    };
+    // Wipe stale `order` values — pinnedOrder reassigns the only ones we
+    // care about, and unpinned/hidden tiles must not carry orders that the
+    // pinned-zone sort would treat as authoritative.
+    for (const cfg of Object.values(this.config.terminals)) {
+      delete cfg.order;
+    }
+    layout.pinnedOrder.forEach((name, i) => {
+      const e = lookup(name);
+      if (!e) return;
+      e.pinned = true;
+      delete e.hidden;
+      e.order = i;
+    });
+    for (const name of layout.unpinnedNames) {
+      const e = lookup(name);
+      if (!e) continue;
+      delete e.pinned;
+      delete e.hidden;
+    }
+    for (const name of layout.hiddenNames) {
+      const e = lookup(name);
+      if (!e) continue;
+      delete e.pinned;
+      e.hidden = true;
+    }
+    // Flip sortMode to 'auto' so the bar's unpinned-tile order matches what
+    // the panel just showed — wiping `order` on unpinned tiles while
+    // sortMode='manual' would otherwise fall back to lastActivity sort and
+    // silently undo any prior in-bar drag-reorder.
+    this.config.sortMode = 'auto';
     this.scheduleSave();
   }
 

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -75,6 +75,16 @@ export interface TerminalConfig {
    * the bar alongside Claude tiles.
    */
   type?: 'claude' | 'shell';
+  /**
+   * v0.19 (#34) — preferred focus hotkey, in VS Code accelerator syntax
+   * (e.g. "ctrl+alt+a", "shift+f7"). Memo only — the extension does NOT
+   * register this binding directly because VS Code has no first-class API
+   * for dynamic keybinding registration. The "Copy hotkey JSON…" right-
+   * click action uses this value as the suggested key when generating a
+   * keybindings.json snippet for the user to paste. Set via that action
+   * or by hand-editing the config.
+   */
+  hotkey?: string | null;
 }
 
 /**
@@ -641,6 +651,22 @@ export class ConfigManager implements vscode.Disposable {
     if (pinned) entry.pinned = true;
     else delete entry.pinned;
     this.scheduleSave();
+  }
+
+  /**
+   * v0.19 (#34) — record the user's preferred focus hotkey on a tile.
+   * Memo only; VS Code can't dynamically register this. The webview's
+   * "Copy hotkey JSON…" action calls this so the chosen key persists
+   * across sessions for any future copy/paste/audit. Empty / null
+   * clears the field.
+   */
+  setHotkey(name: string, key: string | null): boolean {
+    const entry = this.config.terminals[name];
+    if (!entry) return false;
+    if (key && key.length > 0) entry.hotkey = key;
+    else delete entry.hotkey;
+    this.scheduleSave();
+    return true;
   }
 
   /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { DashboardProvider } from './dashboardProvider';
+import { OrganizerProvider } from './organizerProvider';
 import { TerminalTracker } from './terminalTracker';
 import { StatusWatcher } from './statusWatcher';
 import { ConfigManager } from './configManager';
@@ -89,6 +90,7 @@ export function activate(context: vscode.ExtensionContext) {
   const tracker = new TerminalTracker(configManager, log);
   const watcher = new StatusWatcher();
   const provider = new DashboardProvider(context.extensionUri);
+  const organizer = new OrganizerProvider(context.extensionUri, configManager, tracker);
 
   // Register the webview provider
   const registration = vscode.window.registerWebviewViewProvider(
@@ -130,6 +132,10 @@ export function activate(context: vscode.ExtensionContext) {
   const setupProjectsCmd = vscode.commands.registerCommand(
     'claudeDashboard.setupProjects',
     () => runSetupWizard(configManager, context.extensionPath, (m) => log(m)),
+  );
+  const organizeProjectsCmd = vscode.commands.registerCommand(
+    'claudeDashboard.organizeProjects',
+    () => organizer.show(),
   );
   const showHooksCmd = vscode.commands.registerCommand(
     'claudeDashboard.showHooks',
@@ -557,6 +563,8 @@ export function activate(context: vscode.ExtensionContext) {
     registerProjectCmd,
     launchProjectCmd,
     setupProjectsCmd,
+    organizeProjectsCmd,
+    organizer,
     showHooksCmd,
     removeLegacyHooksCmd,
     diagnoseCmd,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -478,6 +478,60 @@ export function activate(context: vscode.ExtensionContext) {
           refreshTiles();
         }
         break;
+
+      case 'copyHotkeyJson': {
+        // v0.19 (#34) — generate a keybindings.json snippet for this tile
+        // and put it on the clipboard. VS Code has no first-class dynamic
+        // keybinding API, so paste-into-keybindings.json is the path that
+        // works today. Pre-fills the InputBox with any prior `hotkey` from
+        // config so the user's choice persists across reopens.
+        const tile = tracker.getTiles().find((t) => t.id === message.id);
+        if (!tile) break;
+        const cfg = configManager.getTerminal(tile.name);
+        const focusName = cfg?.projectName ?? tile.displayName ?? tile.name;
+        const previous = (cfg?.hotkey && typeof cfg.hotkey === 'string') ? cfg.hotkey : '';
+        vscode.window.showInputBox({
+          prompt: `Hotkey for "${tile.displayName}" (e.g. ctrl+alt+a, shift+f7)`,
+          value: previous,
+          placeHolder: 'ctrl+alt+a',
+          validateInput: (raw) => {
+            const v = raw.trim();
+            if (v.length === 0) return null;
+            // Loose check — VS Code accepts pretty-much any string and
+            // surfaces its own parse errors at registration time. We only
+            // catch obvious nonsense (bare modifiers, spaces inside keys).
+            if (!/^[a-zA-Z0-9+\- ]+$/.test(v)) {
+              return 'Use VS Code accelerator syntax — modifiers + key separated by "+" (e.g. ctrl+alt+a).';
+            }
+            return null;
+          },
+        }).then((result) => {
+          if (result === undefined) return;          // user cancelled
+          const key = result.trim();
+          if (key.length === 0) {
+            configManager.setHotkey(tile.name, null);
+            vscode.window.showInformationMessage(`Cleared hotkey for "${tile.displayName}".`);
+            return;
+          }
+          configManager.setHotkey(tile.name, key);
+          const snippet = JSON.stringify({
+            command: 'claudeDashboard.focusByName',
+            args: focusName,
+            key,
+          }, null, 2);
+          void vscode.env.clipboard.writeText(snippet + ',');
+          vscode.window.showInformationMessage(
+            `Hotkey snippet copied. Open keybindings.json (Ctrl+Shift+P → "Open Keyboard Shortcuts (JSON)") and paste inside the array.`,
+            'Open keybindings.json',
+          ).then((choice) => {
+            if (choice === 'Open keybindings.json') {
+              void vscode.commands.executeCommand('workbench.action.openGlobalKeybindingsFile');
+            }
+          });
+          log(`copyHotkeyJson ${tile.name}: → "${key}"`);
+        });
+        break;
+      }
     }
   };
 

--- a/src/organizerProvider.ts
+++ b/src/organizerProvider.ts
@@ -1,0 +1,255 @@
+import * as vscode from 'vscode';
+import { ConfigManager } from './configManager';
+import { TerminalTracker } from './terminalTracker';
+import { getThemeColor } from './types';
+
+/**
+ * v0.19 — tile-organizer panel. Editor-area webview (not sidebar) that
+ * renders four lanes of cards for managing tile visibility and pinning:
+ *
+ *   1. Auto-sort      — running, status-driven order in the bar
+ *   2. Pinned         — fixed-position zone at the bar bottom
+ *   3. Closed visible — registered, terminal not running (passive lane,
+ *                       drop-disabled — tiles auto-appear here)
+ *   4. Hidden         — `hidden: true`, not in the bar at all
+ *
+ * Lanes 1 and 3 share the same `(pinned: false, hidden: false)` config
+ * state — the difference is runtime liveness, derived from TerminalTracker.
+ *
+ * Drag/drop semantics:
+ *   - Drag → Pinned: sets `pinned: true`, position assigns `order`
+ *   - Drag → Auto-sort: sets `pinned: false, hidden: false`, no order
+ *   - Drag → Hidden: sets `hidden: true`
+ *   - Drag → Closed visible: rejected at the webview (passive lane)
+ *
+ * The webview owns the lane layout and ships the full picture back via a
+ * single `applyLayout` message; ConfigManager applies it atomically.
+ */
+export class OrganizerProvider implements vscode.Disposable {
+  private panel: vscode.WebviewPanel | undefined;
+  private extensionUri: vscode.Uri;
+  private configManager: ConfigManager;
+  private tracker: TerminalTracker;
+  private subDisposables: vscode.Disposable[] = [];
+  // Set briefly after our own `applyOrganizerLayout` write so the
+  // configManager.onChange listener (which fires once the debounced disk
+  // write completes) doesn't double-post the same state we just echoed.
+  // External edits — file changed by hand — still trigger a normal sync.
+  private suppressOwnEcho = false;
+  private suppressOwnEchoTimer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(extensionUri: vscode.Uri, configManager: ConfigManager, tracker: TerminalTracker) {
+    this.extensionUri = extensionUri;
+    this.configManager = configManager;
+    this.tracker = tracker;
+  }
+
+  show(): void {
+    if (this.panel) {
+      this.panel.reveal(vscode.ViewColumn.Active);
+      return;
+    }
+    this.panel = vscode.window.createWebviewPanel(
+      'claudelikeBar.organizer',
+      'Organize Claudelike Tiles',
+      vscode.ViewColumn.Active,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
+      },
+    );
+    this.panel.iconPath = vscode.Uri.joinPath(this.extensionUri, 'media', 'dashboard.svg');
+    this.panel.webview.html = this.getHtml(this.panel.webview);
+
+    this.panel.onDidDispose(() => {
+      this.panel = undefined;
+      for (const d of this.subDisposables) d.dispose();
+      this.subDisposables = [];
+    });
+
+    this.subDisposables.push(
+      this.panel.webview.onDidReceiveMessage((msg: unknown) => this.handleMessage(msg)),
+      this.configManager.onChange(() => {
+        if (this.suppressOwnEcho) return;
+        this.postState();
+      }),
+      this.tracker.onChange(() => this.postState()),
+    );
+
+    this.postState();
+  }
+
+  private handleMessage(msg: unknown): void {
+    if (!msg || typeof msg !== 'object') return;
+    const m = msg as { type?: unknown };
+    if (typeof m.type !== 'string') return;
+    if (m.type === 'organizer:applyLayout') {
+      const layout = msg as {
+        pinnedOrder?: unknown;
+        unpinnedNames?: unknown;
+        hiddenNames?: unknown;
+      };
+      const asNameList = (v: unknown): string[] =>
+        Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+      // Suppress the configManager.onChange-triggered postState that fires
+      // ~200ms later (after the debounced save completes) — its payload is
+      // identical to the echo below, and re-posting it would redundantly
+      // rebuild the webview DOM. 300ms covers the 200ms scheduleSave debounce
+      // plus a margin for filesystem-watcher latency.
+      this.suppressOwnEcho = true;
+      if (this.suppressOwnEchoTimer) clearTimeout(this.suppressOwnEchoTimer);
+      this.suppressOwnEchoTimer = setTimeout(() => {
+        this.suppressOwnEcho = false;
+      }, 300);
+      this.configManager.applyOrganizerLayout({
+        pinnedOrder: asNameList(layout.pinnedOrder),
+        unpinnedNames: asNameList(layout.unpinnedNames),
+        hiddenNames: asNameList(layout.hiddenNames),
+      });
+      // Eager echo: webview gets the new state immediately rather than
+      // waiting for the debounced save → onChange round-trip.
+      this.postState();
+    } else if (m.type === 'organizer:requestState') {
+      this.postState();
+    } else if (m.type === 'organizer:launchProject') {
+      void vscode.commands.executeCommand('claudeDashboard.launchProject');
+    } else if (m.type === 'organizer:openConfig') {
+      void vscode.commands.executeCommand('claudeDashboard.openConfig');
+    }
+  }
+
+  private postState(): void {
+    if (!this.panel) return;
+    const all = this.configManager.getAll();
+    const liveNames = new Set(
+      this.tracker.getTiles()
+        .filter((t) => t.status !== 'registered')
+        .map((t) => t.name),
+    );
+    type Card = {
+      name: string;
+      displayName: string;
+      themeColor: string;
+      icon: string | null;
+      isShell: boolean;
+    };
+    const pinned: Array<Card & { order: number }> = [];
+    const auto: Card[] = [];
+    const closedVisible: Card[] = [];
+    const hidden: Card[] = [];
+
+    for (const [name, cfg] of Object.entries(all)) {
+      const card: Card = {
+        name,
+        displayName: cfg.nickname ?? name,
+        themeColor: getThemeColor(name, typeof cfg.color === 'string' ? cfg.color : undefined),
+        icon: cfg.icon ?? null,
+        isShell: cfg.type === 'shell',
+      };
+      if (cfg.hidden) {
+        hidden.push(card);
+      } else if (cfg.pinned) {
+        pinned.push({
+          ...card,
+          order: typeof cfg.order === 'number' ? cfg.order : Number.MAX_SAFE_INTEGER,
+        });
+      } else if (liveNames.has(name)) {
+        auto.push(card);
+      } else {
+        closedVisible.push(card);
+      }
+    }
+
+    pinned.sort((a, b) => a.order - b.order);
+    const cmp = (a: Card, b: Card) => a.displayName.localeCompare(b.displayName);
+    auto.sort(cmp);
+    closedVisible.sort(cmp);
+    hidden.sort(cmp);
+
+    void this.panel.webview.postMessage({
+      type: 'organizer:state',
+      lanes: {
+        pinned: pinned.map(({ order: _o, ...c }) => c),
+        auto,
+        closedVisible,
+        hidden,
+      },
+    });
+  }
+
+  private getHtml(webview: vscode.Webview): string {
+    const cssUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'organizer.css'));
+    const jsUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'organizer.js'));
+    const codiconCssUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'codicon.css'));
+    const codiconFontUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'codicon.ttf'));
+    const nonce = getNonce();
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; style-src ${webview.cspSource} 'nonce-${nonce}'; font-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style nonce="${nonce}">
+    @font-face {
+      font-family: "codicon";
+      font-display: block;
+      src: url("${codiconFontUri}") format("truetype");
+    }
+  </style>
+  <link href="${codiconCssUri}" rel="stylesheet">
+  <link href="${cssUri}" rel="stylesheet">
+</head>
+<body>
+  <header class="organizer-header">
+    <h1>Organize Claudelike Tiles</h1>
+    <p class="hint">Drag cards between lanes to pin, hide, or unhide tiles. Closed but visible is passive — cards land there automatically when their terminal exits.</p>
+  </header>
+  <main class="lanes">
+    <section class="lane" data-lane="pinned">
+      <header><span class="lane-title">Pinned</span><span class="lane-sub">Fixed at bar bottom — drag to reorder</span></header>
+      <div class="cards" data-droppable="true"></div>
+    </section>
+    <section class="lane" data-lane="auto">
+      <header><span class="lane-title">Auto-sort</span><span class="lane-sub">Running tiles, status-driven order</span></header>
+      <div class="cards" data-droppable="true"></div>
+    </section>
+    <section class="lane" data-lane="closedVisible">
+      <header><span class="lane-title">Closed but visible</span><span class="lane-sub">Click in the bar to launch — tiles land here when their terminal exits</span></header>
+      <div class="cards" data-droppable="false"></div>
+    </section>
+    <section class="lane" data-lane="hidden">
+      <header><span class="lane-title">Hidden</span><span class="lane-sub">Not shown in the bar — reachable via Launch Project</span></header>
+      <div class="cards" data-droppable="true"></div>
+    </section>
+  </main>
+  <footer class="organizer-footer">
+    <button type="button" data-action="openConfig">Edit config file…</button>
+    <span class="status" id="status"></span>
+  </footer>
+  <script nonce="${nonce}" src="${jsUri}"></script>
+</body>
+</html>`;
+  }
+
+  dispose(): void {
+    if (this.suppressOwnEchoTimer) {
+      clearTimeout(this.suppressOwnEchoTimer);
+      this.suppressOwnEchoTimer = undefined;
+    }
+    for (const d of this.subDisposables) d.dispose();
+    this.subDisposables = [];
+    this.panel?.dispose();
+  }
+}
+
+function getNonce(): string {
+  let text = '';
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 32; i++) {
+    text += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return text;
+}

--- a/src/terminalTracker.ts
+++ b/src/terminalTracker.ts
@@ -19,6 +19,12 @@ const STATUS_FRESH_MS = 60_000;
 // genuinely-stale counter clears within the next attention window.
 const SUBAGENT_WATCHDOG_MS = 60_000;
 
+// v0.19 (#36) — burst window for the "freshly ready" pulse. Long enough to
+// notice across a peripheral glance, short enough to fade before it becomes
+// background noise. Mirrors the audio chime as the canonical "this just
+// finished" cue.
+const FRESHLY_READY_MS = 3_000;
+
 // Status values that mean "Claude is not actively running" — suppression of
 // the registered tile doesn't apply to these. `idle` is included because a
 // fresh idle file just means the hook fired on session start/end; the slug
@@ -62,6 +68,12 @@ export class TerminalTracker implements vscode.Disposable {
   // zero the counter. Catches the in-turn fan-out case the v0.14.1 Stop-
   // reset doesn't cover (long agentic turns that never yield a parent Stop).
   private subagentWatchdogTimers = new Map<number, NodeJS.Timeout>();
+
+  // v0.19 (#36) — per-tile timer that clears the `freshlyReady` flag after
+  // FRESHLY_READY_MS. Cancelled if the tile transitions out of ready before
+  // the timer fires (avoids a spurious "fresh" pulse on a tile that already
+  // moved on).
+  private freshlyReadyTimers = new Map<number, NodeJS.Timeout>();
 
   // Focus tracking: which tile was focused while in "waiting" state
   private focusedWaitingTile: number | null = null;
@@ -568,6 +580,7 @@ export class TerminalTracker implements vscode.Disposable {
             tile.status = 'ready';
             tile.statusLabel = this.configManager.getLabel('ready');
             tile.ignoredText = undefined;
+            this.markFreshlyReady(tile);
             this.startReadyTimer(tile.id);
             changed = true;
           }
@@ -677,6 +690,7 @@ export class TerminalTracker implements vscode.Disposable {
             // the flag was stale). Clear it so it doesn't resurface if the
             // tile later cycles through working again.
             tile.subagentPermissionPending = false;
+            this.markFreshlyReady(tile);
             this.startReadyTimer(tile.id);
             changed = true;
           } else if (tile.statusLabel !== newLabel) {
@@ -863,6 +877,11 @@ export class TerminalTracker implements vscode.Disposable {
       if (changed) {
         tile.lastActivity = Date.now();
         tile.event = event;
+        // v0.19 (#36) — clear fresh-ready on transitions out of ready.
+        // Label-only refreshes (ready → ready) leave both alone.
+        if (prev === 'ready' && tile.status !== 'ready') {
+          this.clearFreshlyReady(tile);
+        }
         this.log(() => `transition ${tile.name}: ${prev} → ${tile.status} (event=${event ?? '-'})`);
         // v0.12 — emit state transition for audio + other downstream
         // consumers. Fires on every status change (not label-only refreshes).
@@ -924,6 +943,44 @@ export class TerminalTracker implements vscode.Disposable {
     if (existing) {
       clearTimeout(existing);
       this.readyTimers.delete(id);
+    }
+  }
+
+  /**
+   * v0.19 (#36) — stamp a tile as just-now-ready. Sets `readyAt` for the
+   * sort comparator (so the tile floats to the top of the ready band) and
+   * `freshlyReady` for the webview's brighter burst pulse. The flag clears
+   * after FRESHLY_READY_MS via a per-tile timer that fires `onChange` so
+   * the webview repaints.
+   */
+  private markFreshlyReady(tile: TileData): void {
+    tile.readyAt = Date.now();
+    tile.freshlyReady = true;
+    const existing = this.freshlyReadyTimers.get(tile.id);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      this.freshlyReadyTimers.delete(tile.id);
+      const live = this.terminals.get(tile.id);
+      if (!live || !live.freshlyReady) return;
+      live.freshlyReady = false;
+      this.onChangeEmitter.fire();
+    }, FRESHLY_READY_MS);
+    this.freshlyReadyTimers.set(tile.id, timer);
+  }
+
+  /**
+   * v0.19 (#36) — wipe the freshly-ready stamp + cancel the pending decay
+   * timer. Called from the central transition-out-of-ready check so working
+   * / done / error / offline transitions don't leave a stale "fresh" pulse
+   * on a tile that's no longer ready.
+   */
+  private clearFreshlyReady(tile: TileData): void {
+    tile.readyAt = undefined;
+    tile.freshlyReady = false;
+    const existing = this.freshlyReadyTimers.get(tile.id);
+    if (existing) {
+      clearTimeout(existing);
+      this.freshlyReadyTimers.delete(tile.id);
     }
   }
 
@@ -1103,6 +1160,16 @@ export class TerminalTracker implements vscode.Disposable {
       unpinned.sort((a, b) => {
         const orderDiff = (statusOrder[a.status] ?? 5) - (statusOrder[b.status] ?? 5);
         if (orderDiff !== 0) return orderDiff;
+        // v0.19 (#36) — within the ready band, sort by transition-into-ready
+        // time descending so the just-now-ready tile sits at the top. Falls
+        // back to lastActivity for tiles without readyAt (e.g. the
+        // subagentPermissionPending → ready render-only promotion above,
+        // which doesn't go through the ready-transition code path).
+        if (a.status === 'ready' && b.status === 'ready') {
+          const ar = a.readyAt ?? a.lastActivity;
+          const br = b.readyAt ?? b.lastActivity;
+          return br - ar;
+        }
         return b.lastActivity - a.lastActivity;
       });
     }
@@ -1113,14 +1180,14 @@ export class TerminalTracker implements vscode.Disposable {
     const registered = this.configManager.getShowRegisteredProjects()
       ? this.synthesizeRegisteredTiles(new Set(all.map((t) => t.name)))
       : [];
-    registered.sort((a, b) => {
-      const ao = this.configManager.getTerminal(a.name)?.order;
-      const bo = this.configManager.getTerminal(b.name)?.order;
-      if (ao !== undefined && bo !== undefined && ao !== bo) return ao - bo;
-      if (ao !== undefined && bo === undefined) return -1;
-      if (ao === undefined && bo !== undefined) return 1;
-      return a.name.localeCompare(b.name);
-    });
+    // v0.19 (#37) — strict alphabetical by displayName. Registered tiles
+    // aren't drag-reorderable in the bar (only running tiles in manual sort
+    // are), so any `order` field on a registered entry is by definition
+    // stale state from a prior session. displayName (nickname || name)
+    // matches what the user actually sees on the tile.
+    registered.sort((a, b) =>
+      a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }),
+    );
 
     return [...unpinned, ...pinned, ...registered];
   }
@@ -1245,6 +1312,10 @@ export class TerminalTracker implements vscode.Disposable {
       clearTimeout(timer);
     }
     this.subagentWatchdogTimers.clear();
+    for (const timer of this.freshlyReadyTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.freshlyReadyTimers.clear();
     for (const d of this.disposables) d.dispose();
     this.terminals.clear();
     this.terminalRefs.clear();

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,18 @@ export interface TileData {
   // has been submitted yet for this tile.
   lastPrompt?: string;
   lastPromptAt?: number;
+  // v0.19 (#36) — millisecond timestamp of the most recent transition
+  // *into* `ready`. Used by the auto-mode comparator to keep newly-ready
+  // tiles at the top of the ready band (vs. ageing-by-other-events drift
+  // when the band falls back to lastActivity). Cleared on transitions
+  // out of ready (working/done/error/offline). Undefined for tiles that
+  // were never ready or have moved on.
+  readyAt?: number;
+  // v0.19 (#36) — true for ~3s after a ready transition. Webview adds a
+  // .fresh class for a brighter / faster pulse so the user can see at a
+  // glance which tile just transitioned. Decays via a tracker timer that
+  // fires onChange when it clears.
+  freshlyReady?: boolean;
 }
 
 /**
@@ -107,6 +119,7 @@ export type WebviewMessage =
   | { type: 'showLastPrompt'; id: number }
   | { type: 'launchByName'; name: string }
   | { type: 'hideRegisteredTile'; name: string }
+  | { type: 'copyHotkeyJson'; id: number }
   // v0.12 — webview → extension acks after an audio play attempt. Only the
   // internal __firePlayForTest command consumes these; production code
   // ignores them. Kept always-on so the CI smoke test doesn't need a

--- a/test/pinned.test.ts
+++ b/test/pinned.test.ts
@@ -90,6 +90,121 @@ describe('ConfigManager.setHidden (#27)', () => {
   });
 });
 
+describe('ConfigManager.applyOrganizerLayout (tile-organizer panel)', () => {
+  it('pins listed names with sequential order, clears prior pinned/hidden flags', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, hidden: true },
+        'b': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+        'c': { color: 'cyan', icon: null, nickname: null, autoStart: false, pinned: true, order: 9 },
+      },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.applyOrganizerLayout({
+      pinnedOrder: ['b', 'a'],
+      unpinnedNames: ['c'],
+      hiddenNames: [],
+    });
+    expect(cm.getTerminal('b')?.pinned).toBe(true);
+    expect(cm.getTerminal('b')?.order).toBe(0);
+    expect(cm.getTerminal('a')?.pinned).toBe(true);
+    expect(cm.getTerminal('a')?.hidden).toBeUndefined();
+    expect(cm.getTerminal('a')?.order).toBe(1);
+    expect(cm.getTerminal('c')?.pinned).toBeUndefined();
+    expect(cm.getTerminal('c')?.order).toBeUndefined();
+    cm.dispose();
+  });
+
+  it('hidden lane sets hidden:true and clears pinned', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, pinned: true, order: 0 },
+      },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.applyOrganizerLayout({
+      pinnedOrder: [],
+      unpinnedNames: [],
+      hiddenNames: ['a'],
+    });
+    expect(cm.getTerminal('a')?.hidden).toBe(true);
+    expect(cm.getTerminal('a')?.pinned).toBeUndefined();
+    expect(cm.getTerminal('a')?.order).toBeUndefined();
+    cm.dispose();
+  });
+
+  it('unpinned lane clears both pinned and hidden', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, hidden: true },
+      },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.applyOrganizerLayout({
+      pinnedOrder: [],
+      unpinnedNames: ['a'],
+      hiddenNames: [],
+    });
+    expect(cm.getTerminal('a')?.pinned).toBeUndefined();
+    expect(cm.getTerminal('a')?.hidden).toBeUndefined();
+    cm.dispose();
+  });
+
+  it('ignores names that have no matching config entry (defensive)', () => {
+    writeConfig({ terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    expect(() => cm.applyOrganizerLayout({
+      pinnedOrder: ['ghost'],
+      unpinnedNames: ['phantom'],
+      hiddenNames: ['void'],
+    })).not.toThrow();
+    cm.dispose();
+  });
+
+  it('rejects reserved property names (no prototype pollution)', () => {
+    writeConfig({
+      terminals: { 'a': { color: 'cyan', icon: null, nickname: null, autoStart: false } },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.applyOrganizerLayout({
+      pinnedOrder: ['__proto__', 'constructor', 'a'],
+      unpinnedNames: ['prototype'],
+      hiddenNames: ['__proto__'],
+    });
+    // Object.prototype must not gain pinned/hidden/order.
+    expect((Object.prototype as { pinned?: unknown }).pinned).toBeUndefined();
+    expect((Object.prototype as { hidden?: unknown }).hidden).toBeUndefined();
+    expect((Object.prototype as { order?: unknown }).order).toBeUndefined();
+    // The legitimate entry still applied — pinned with order=2 because
+    // the two reserved entries ahead of it consumed indices 0 and 1.
+    expect(cm.getTerminal('a')?.pinned).toBe(true);
+    expect(cm.getTerminal('a')?.order).toBe(2);
+    cm.dispose();
+  });
+
+  it("flips sortMode to 'auto' so manual order isn't silently lost", () => {
+    writeConfig({
+      sortMode: 'manual',
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, order: 2 },
+        'b': { color: 'cyan', icon: null, nickname: null, autoStart: false, order: 0 },
+        'c': { color: 'cyan', icon: null, nickname: null, autoStart: false, order: 1 },
+      },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.applyOrganizerLayout({
+      pinnedOrder: [],
+      unpinnedNames: ['a', 'b', 'c'],
+      hiddenNames: [],
+    });
+    expect(cm.getSortMode()).toBe('auto');
+    expect(cm.getTerminal('a')?.order).toBeUndefined();
+    expect(cm.getTerminal('b')?.order).toBeUndefined();
+    expect(cm.getTerminal('c')?.order).toBeUndefined();
+    cm.dispose();
+  });
+});
+
 describe('TerminalTracker.getTiles — pinned zone', () => {
   it('places pinned tiles at the bottom in auto sort mode, regardless of urgency', () => {
     writeConfig({

--- a/test/pinned.test.ts
+++ b/test/pinned.test.ts
@@ -65,6 +65,27 @@ describe('ConfigManager.setPinned', () => {
   });
 });
 
+describe('ConfigManager.setHotkey (#34)', () => {
+  it('writes the hotkey value when set, deletes the field when cleared', () => {
+    writeConfig({
+      terminals: { 'a': { color: 'cyan', icon: null, nickname: null, autoStart: false } },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    expect(cm.setHotkey('a', 'ctrl+alt+a')).toBe(true);
+    expect(cm.getTerminal('a')?.hotkey).toBe('ctrl+alt+a');
+    expect(cm.setHotkey('a', null)).toBe(true);
+    expect(cm.getTerminal('a')?.hotkey).toBeUndefined();
+    cm.dispose();
+  });
+
+  it('returns false for unknown terminal', () => {
+    writeConfig({ terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    expect(cm.setHotkey('nope', 'ctrl+alt+a')).toBe(false);
+    cm.dispose();
+  });
+});
+
 describe('ConfigManager.setHidden (#27)', () => {
   it('writes hidden: true when set', () => {
     writeConfig({ terminals: { 'a': { color: 'cyan', icon: null, nickname: null, autoStart: false } } });
@@ -368,6 +389,83 @@ describe('TerminalTracker.getTiles — registered (offline) tiles (#15)', () => 
     const order = tracker.getTiles().map((t) => t.name);
     // live first (unpinned), pinned next, registered last
     expect(order).toEqual(['live', 'pinned-one', 'reg-one']);
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it('sorts registered tiles alphabetically by displayName, ignoring stale order field (#37)', () => {
+    writeConfig({
+      terminals: {
+        'zebra':       { color: 'cyan', icon: null, nickname: null, autoStart: false, order: 0 },
+        'alpha-proj':  { color: 'cyan', icon: null, nickname: 'Aardvark', autoStart: false },
+        'middle':      { color: 'cyan', icon: null, nickname: null, autoStart: false, order: 99 },
+      },
+    });
+    // No live VS Code terminals — all three synthesize as registered tiles.
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    const order = tracker.getTiles().map((t) => t.displayName);
+    // Aardvark (nickname for alpha-proj) → middle → zebra; the stale
+    // `order: 0` on zebra MUST NOT float it to the top.
+    expect(order).toEqual(['Aardvark', 'middle', 'zebra']);
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it('newly-ready tile floats to the top of the ready band (#36)', () => {
+    writeConfig({
+      sortMode: 'auto',
+      terminals: {
+        'old-ready': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+        'new-ready': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+      },
+    });
+    addMockTerminal('old-ready');
+    addMockTerminal('new-ready');
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    tracker.updateStatus('old-ready', 'working', 'PreToolUse');
+    tracker.updateStatus('old-ready', 'ready', 'Stop');
+    // Tiny gap so readyAt timestamps differ.
+    const oldReadyAt = tracker.getTiles().find((t) => t.name === 'old-ready')?.readyAt;
+    expect(typeof oldReadyAt).toBe('number');
+    // Force a later timestamp on new-ready by setting Date.now offset.
+    const realNow = Date.now;
+    const offset = (oldReadyAt as number) + 1000;
+    Date.now = () => offset;
+    tracker.updateStatus('new-ready', 'working', 'PreToolUse');
+    tracker.updateStatus('new-ready', 'ready', 'Stop');
+    Date.now = realNow;
+
+    const readyOrder = tracker.getTiles()
+      .filter((t) => t.status === 'ready')
+      .map((t) => t.name);
+    expect(readyOrder).toEqual(['new-ready', 'old-ready']);
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it('freshlyReady is set on ready transition and clears when transitioning out (#36)', () => {
+    writeConfig({
+      terminals: { 'p': { color: 'cyan', icon: null, nickname: null, autoStart: false } },
+    });
+    addMockTerminal('p');
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    tracker.updateStatus('p', 'working', 'PreToolUse');
+    tracker.updateStatus('p', 'ready', 'Stop');
+    expect(tracker.getTiles().find((t) => t.name === 'p')?.freshlyReady).toBe(true);
+
+    // Transition out of ready clears the flag.
+    tracker.updateStatus('p', 'working', 'PreToolUse');
+    expect(tracker.getTiles().find((t) => t.name === 'p')?.freshlyReady).toBe(false);
+    expect(tracker.getTiles().find((t) => t.name === 'p')?.readyAt).toBeUndefined();
 
     tracker.dispose();
     cm.dispose();


### PR DESCRIPTION
## Summary

- New editor-area webview surfaces all known tiles in four lanes (Auto-sort / Pinned / Closed-but-visible / Hidden), so visibility and pinning are one drag away instead of context-menu-per-tile spelunking.
- Lane membership maps onto the existing `pinned` / `hidden` / `order` primitives — no schema bump.
- Closed-but-visible is a passive (drop-disabled) lane: tiles auto-appear there when their terminal exits, and dragging never terminates a running session.
- Reachable from the palette (\"Claudelike Bar: Organize Projects\") and a new view-title icon next to the gear.

Scoping notes live in \`docs/backlog.md\`. Code-reviewed via the project's 4-agent + judge skill before merge — all 6 review findings (1 prototype-pollution warning, 4 lifecycle/perf warnings, 1 dragover hot-path suggestion) addressed inline. 421 tests passing.

## Test plan

- [x] Open the panel via the new layout icon next to the gear in the sidebar
- [x] Drag a registered (offline) tile from \"Closed but visible\" to \"Pinned\" — bar shows it in the pinned zone with the chosen position; terminal does **not** auto-launch (by design — drag = config edit, not runtime action); next manual launch respects the pinned order
- [x] Drag a Pinned tile to Hidden — disappears from the bar; \"Launch Project\" palette command still finds it _(panel-side passes; bar-side broken — see #39)_
- [x] Drag a Hidden tile back to Auto-sort — re-appears, status-driven
- [x] Try dragging *into* Closed-but-visible — rejected with no-drop cursor; passive lane never accepts drops
- [ ] Edit \`~/.claude/claudelike-bar.jsonc\` by hand while the panel is open — panel re-syncs live via the existing config watcher
- [ ] Reorder pinned tiles within the lane — order persists across reload
- [ ] Close panel and reopen — no listener leaks (\`onDidReceiveMessage\` disposable now tracked)
- [ ] Open the panel, kick off a long-running task in another tile, drag mid-task — status events arriving during the drag are buffered, not clobbering the dragged DOM node
- [ ] Confirm \`__proto__\` / \`constructor\` etc. as tile names cannot pollute the prototype (covered by unit test, smoke-confirm in dev)

## Issues found during testing

- **#38** — Tile dragged from \"Closed but visible\" → \"Auto-sort\" snaps back instantly (lane derivation runtime-vs-config).
- **#39** — Pinned → Hidden does not hide live tiles from the bar (missing \`hidden\` filter in \`terminalTracker.ts:1126\` live-tile path).
- **#40** — Pinned → Auto-sort: tile does not visibly move on the bar.
- **#41** — Drag into \"Closed but visible\" silently rejected — UX cue too weak (no-drop cursor is too subtle).

## Related

- Scoped 2026-05-09 in \`docs/backlog.md\` (entry kept in this branch as historical context)
- Companion issues filed for follow-on work: #33 (audio chime drops) and #34 (per-tile focus hotkeys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)