### PR TITLE
feat(0.20.0): #55 — broadcast palette command for all tracked terminals

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -86,6 +86,100 @@ Open scope questions for triage:
 
 Leverage more of Claude Code's 27 hook event types. Partially done (v0.9.0 added multi-agent + error matchers, v0.9.1 added compaction + lifecycle, v0.9.3 added PostToolUse). Remaining opportunities: TaskCreated/TaskCompleted (show task progress count on tile).
 
+### Tile icons accept SVG file paths, not just codicon names
+**Requested:** 2026-05-09 (Matt)
+
+The `icon` field on a terminal entry currently only accepts codicon names (`types.ts:41` — `icon: string | null` documented as "codicon name"). The webview renders them via `codicon codicon-${name}` (`webview.js:195`). This means CLB's own activity-bar icon (`media/dashboard.svg`) can't be reused on the `claudelike-bar` *tile* — same extension, two icon systems.
+
+Want: support an SVG file path alternative so any extension-bundled or user-supplied SVG can be used as a tile icon. Detect by extension (`.svg`) or by leading `/` / `media/` prefix and route to a different render path.
+
+**Scope.**
+
+1. Type change: `icon: string | null` → `icon: string | null` with documented dual-meaning, OR a tagged shape like `icon: { codicon: string } | { svg: string }`. Lean on the first (string-with-detection) for back-compat — every existing config keeps working.
+2. Render path: in `webview.js`, when `tile.icon` ends in `.svg` or starts with `/`, render `<img src=${webview.asWebviewUri(file)}>` instead of the codicon span. Need to pipe the SVG file through `webview.asWebviewUri()` — the dashboard provider already has the webview reference, so resolution happens extension-side and the URI is sent to the webview pre-resolved.
+3. Security: only allow paths within `extensionPath/media/` and `~/.claude/icons/` (a new convention dir). Reject anything else to avoid accidentally exposing arbitrary filesystem reads via the webview.
+4. Color tinting: codicons inherit `currentColor`, so the existing per-tile color theming "just works." For SVG `<img>`, color doesn't bleed through. Either (a) require tile-icon SVGs to use `currentColor` and inline them as `<svg>` tags rather than `<img>` (small fetch-and-inline pass), or (b) accept that user-supplied SVGs render at their own colors and document it. Option (a) is more work but preserves the visual consistency — every other tile gets its color from the per-tile `color` field.
+
+**Effort estimate:** 30–45 min for the simple `<img>` version, +15 min for inline-SVG tinting. Tests: one for each new resolution path (codicon-name, .svg path, invalid path).
+
+**Concrete trigger:** the `claudelike-bar` tile in Matt's bar — it currently uses codicon `extensions` (puzzle piece) because the activity-bar icon at `media/dashboard.svg` isn't reusable. Closing the gap lets the tile match the activity-bar icon.
+
+### Audio enabled by default for fresh installs
+**Requested:** 2026-05-09 (Matt)
+
+Today, a fresh install ships with `audio.enabled: false` — users have to discover and flip it on to hear anything. Most users want a chime when Claude finishes a turn (it's the bar's whole differentiator over the built-in terminal). Flip the default so new installs come up with audio on, using the bundled `can-crack.mp3` for `turnDone`.
+
+**Current behavior:**
+- Runtime check at `configManager.ts:480`: `return this.config.audio?.enabled === true;` → `undefined` reads as `false`.
+- Config writer at `configManager.ts:892`: `enabled: rawAudio.enabled === true` → fresh writes `enabled: false`.
+- `freshAudioBlock` flag at `configManager.ts:886` already detects "user has never touched the audio block" — re-use this signal.
+
+**Proposed change:**
+- Define `DEFAULT_AUDIO_ENABLED = true` constant alongside `DEFAULT_TURN_DONE_SOUND` in `claudePaths.ts`.
+- `isAudioEnabled()` (line 480) → return `this.config.audio?.enabled !== false` (default true unless explicitly disabled).
+- `generateConfigText()` (line 892) → write `enabled: rawAudio.enabled !== false` for fresh blocks; honor explicit `false` when user has set it.
+- Existing users who've never touched `audio.enabled` will hear sound on next start. That's arguably the desired behavior (the chime is the feature) but worth a release note + minor version bump.
+
+**Effort estimate:** 5–10 min code change + 5 min release note. Tests: assert fresh-config audio is on; assert explicit `enabled: false` is honored.
+
+**Caveats:**
+- Behavior change for existing users — covered by release notes. Flipping a default ON is gentler than OFF; users who don't want audio just flip it back.
+- `can-crack.mp3` resolves from the bundled extension directory if absent in `~/.claude/sounds/`, so no missing-file edge case.
+- Volume default `DEFAULT_AUDIO_VOLUME = 0.6` and debounce `DEFAULT_AUDIO_DEBOUNCE_MS = 150` already sensible — no change needed.
+
+### Project-organizer panel — drag/drop tiles between visibility lanes
+**Requested:** 2026-05-09 (Matt)
+
+The bar accumulates tiles fast (currently 28 entries in `.claudelike-bar.jsonc`). Today, getting a project out of the bar means right-click → "Hide from bar"; getting it back means the command palette; pinning is a context menu toggle; reordering is drag-within-bar. Four interactions, three locations. Want a single management panel — a "kanban" view of all known tiles, sorted into lanes by their current `(pinned, hidden)` flag combo, with drag/drop to move between lanes and reorder within them.
+
+**Lanes** (mapping to existing flags — no new data primitives needed):
+
+| Lane | `pinned` | `hidden` | Today's behavior |
+|---|---|---|---|
+| Auto-sort | false | false | Status-driven order in bar (current default) |
+| Pinned | true | false | Fixed-order zone at bar bottom, drag-reorderable |
+| Closed but visible | false | false + project terminal not running | Same as Auto-sort lane today — tile shown, click to launch |
+| Closed and not visible | — | true | Hidden from bar; reachable via command palette only |
+
+Caveat: lanes 1 and 3 collapse to the same `(pinned: false, hidden: false)` config state — the difference between them is runtime (terminal alive vs not), not config. **Decision (2026-05-09, Matt):** treat "Closed but visible" as a *passive* lane — tiles auto-appear there when their terminal exits, and you can't drag *into* it. Dragging *out of* it to Pinned or Closed-and-not-visible flips a flag; dragging to Auto-sort launches the project. This avoids the "kill-by-drag" footgun where dragging would terminate a running terminal. Lane membership for `(false, false)` tiles is derived from `dashboardProvider` runtime state, not a new config field.
+
+**Scope.**
+
+What already exists in the codebase:
+
+- `pinned: boolean` flag (`configManager.ts:59`), `setPinned()` method (`configManager.ts:633`).
+- `hidden: boolean` flag (`configManager.ts:68`), `setHidden()` method (`configManager.ts:647`).
+- `order: number` field + `setOrder(orderedNames: string[])` for drag-reorder (`configManager.ts:661`).
+- "Hide from bar" right-click action (`webview.js:518`) and pin toggle (`webview.js:548`).
+- Drag-and-drop within the bar that flips `sortMode` to manual.
+
+What's needed:
+
+1. **New webview panel** — separate from the sidebar bar (sidebar is too narrow for 4 columns). Open via gear menu or command "Claudelike Bar: Organize Projects". Renders 4 vertical columns of tile-shaped cards.
+2. **Drop handler** that translates `(srcLane, dstLane, position)` into the right combination of `setPinned` / `setHidden` / `setOrder` calls atomically. ~30 lines in `configManager.ts`.
+3. **HTML5 native DnD or a tiny lib** (e.g. SortableJS, ~12 KB) for cross-column drag with drop placeholders. Native DnD works but the cross-column-with-position UX is finicky; SortableJS pays for itself here.
+4. **Live re-sync** — panel listens to the same config-file watcher the bar uses; if you tweak the JSONC by hand, the panel updates. Reuse `dashboardProvider`'s update mechanism.
+
+What's *not* in scope (worth deferring):
+
+- Bulk operations (multi-select drag) — start with single-tile DnD, add multi-select if the v1 doesn't feel fast enough.
+- Search/filter within the panel — at 28 tiles this is fine; revisit at 50+.
+- Editing tile color/icon/nickname inline — keep that in the existing right-click menu / config file. Panel is purely about lane membership and order.
+
+**Effort estimate:** 60-90 minutes of Claude time for v1.
+- Backend (`configManager` lane-move method + extension command + panel registration): ~20 min
+- Webview panel HTML/CSS skeleton: ~15 min
+- DnD wiring (SortableJS or native + drop targets): ~25 min
+- Live re-sync via existing config-watcher: ~10 min
+- Tests (lane-move atomicity, DnD message round-trip via `webview-syntax.test.ts` style): ~15 min
+
+Risk areas:
+- Atomic flag flips when crossing lanes — easy to leave a tile in a half-state if the user drags fast and the messages reorder. Mitigation: single `moveTile(name, lane, position)` API that does all flag changes inside one config write, not three separate `setPinned`/`setHidden`/`setOrder` round-trips.
+- Distinguishing "auto-sort" vs "closed but visible" if going with option 1 above — needs the panel to read live tile state from `dashboardProvider`, not just config. Minor coupling but worth it to avoid the schema bump.
+- VS Code webview reload on theme change wiping local DnD state — known annoyance in other panels; standard fix is to persist the panel state in `webview.state` API.
+
+**Open question:** sidebar webview vs editor-area webview panel? Editor-area has more room for a 4-column kanban; sidebar can host a vertical-stack version (2 columns × 2 stacks). Lean editor-area for a real kanban feel.
+
 ## Deferred Design Work
 
 ### Crash watchdog

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -38,6 +38,56 @@ Counter math from this window alone is balanced (5 Start / 6 Stop → floors at 
 
 ## Feature Requests
 
+### User-configurable focus hotkeys per tile
+**Requested:** 2026-05-09 (Matt)
+
+The `claudeDashboard.focusByName` and `claudeDashboard.focusSlot1..9` commands already exist (#18, shipped v0.16.5) and work — but binding them requires hand-editing `~/.config/Code/User/keybindings.json`, which most users won't do. Want a discoverable path: per-tile hotkey assignment from the config file or a right-click "Set hotkey…" action, plus default bindings out of the box for the slot variants.
+
+**Scope.**
+
+What already exists:
+- `claudeDashboard.focusSlot1..9` — focuses the Nth live tile in current sort order (`extension.ts:196–222`)
+- `claudeDashboard.focusByName` — focuses a tile by displayName / name / projectName, takes a string `args` value (`extension.ts:224–250`)
+- Both commands resolve the underlying `vscode.Terminal` via `tracker.getTerminalById` and call `term.show()`. No UI surface.
+
+What's needed:
+
+1. **Default keybindings for the slot commands.** Ship a `contributes.keybindings` block in `package.json` that binds `Ctrl+Alt+1..9` (Linux/Windows) / `Cmd+Alt+1..9` (macOS) to `focusSlot1..9`. These combos are mostly free — VS Code uses `Ctrl+1..9` for editor groups and `Ctrl+\`+1..9` for terminal switching, but `Ctrl+Alt+1..9` is unclaimed in default bindings as of 1.93. Users can override in their own keybindings.json if they conflict with another extension.
+2. **Per-tile hotkey config field.** Add an optional `hotkey: string` field to `TerminalConfig` (e.g. `"hotkey": "ctrl+alt+a"`). On config load, dynamically register a keybinding via `vscode.commands.executeCommand` + the `setContext` pattern, OR (simpler) maintain a generated keybindings.json snippet the user can copy. Discoverability beats elegance — even a "Copy hotkey JSON" action in the right-click menu is a win.
+3. **Right-click "Set hotkey…" action.** InputBox prompts for a key combo, validates against a small allowlist of safe modifier patterns (see below), writes to the tile's `hotkey` field. Activation reads all `hotkey` fields and registers them. On conflict (same hotkey on two tiles, or hotkey claimed by VS Code), surface a warning toast pointing the user to keybindings.json.
+4. **F-key option.** Plain `F1..F12` in VS Code are mostly reserved (F1=palette, F2=rename, F5=debug, F8=problems, etc.). Modifier+F-key is much safer: `Ctrl+F1..F12`, `Alt+F1..F12`, `Ctrl+Shift+F1..F12` are largely free. Document these as the recommended option for users with >9 tiles or who want non-numeric mnemonic mappings (e.g. F1=api, F2=belfry).
+
+**Modifier collision map** (VS Code 1.93 defaults):
+
+| Combo | Status |
+|---|---|
+| `Ctrl+1..9` | TAKEN — switch editor group |
+| `` Ctrl+`+1..9 `` | TAKEN — switch active terminal |
+| `Ctrl+Alt+1..9` | FREE on Linux/Win; some Mac debug bindings — recommended default |
+| `Ctrl+Shift+1..9` | mostly FREE |
+| `Alt+1..9` | FREE on Linux/Win; menu mnemonics on some platforms |
+| `F1..F12` (plain) | mostly TAKEN |
+| `Ctrl+F1..F12` | mostly FREE |
+| `Alt+F1..F12` | mostly FREE |
+| `Ctrl+Shift+F1..F12` | mostly FREE |
+
+**What's *not* in scope:**
+- Cross-window hotkey routing — focus stays within the current VS Code window. Multi-window users are on their own.
+- Chord shortcuts (e.g. `Ctrl+K Ctrl+1`) — interesting later but the per-tile UX gets harder to validate.
+- Hotkey for non-focus actions (kill, mark-done, etc.) — keep this scoped to the focus use case.
+
+**Effort estimate:** 30–60 minutes for v1.
+- Default `Ctrl+Alt+1..9` keybindings block in package.json: ~5 min
+- Per-tile `hotkey` field + dynamic registration on activation: ~20 min
+- "Set hotkey…" right-click action with validation: ~20 min
+- Docs + collision-map note in README: ~10 min
+
+Risk areas:
+- Dynamic keybinding registration in VS Code: there's no first-class API for this. Workarounds include shipping `when` clauses gated on a context key + maintaining a generated keybindings.json fragment, or simply emitting a "Paste this into your keybindings.json" toast. Pick the cheaper one for v1.
+- Hotkey conflicts that only manifest in specific workspaces (other extensions). Resolution path: document the override pattern (`-claudeDashboard.focusSlot1` to disable) rather than try to detect.
+
+**Open question:** validate `hotkey` strings against VS Code's accelerator grammar at write-time, or accept anything and let the keybinding registration fail silently? The latter is simpler but harder to debug. Lean validation — we already have a small allowlist of safe modifier patterns from the collision map above.
+
 ### Context menu: "Switch to auto sort"
 **Requested:** 2026-04-16 (Matt)
 

--- a/docs/v0.19.1-plan.md
+++ b/docs/v0.19.1-plan.md
@@ -1,0 +1,190 @@
+# v0.19.1 plan — organizer target-state refactor
+
+**Status:** implemented; ready for manual QA and merge
+**Tracking issue:** #46 (organizer panel: target-state declarative model)
+**Branch:** `feature/tile-organizer-panel` (PR #35)
+**Predecessor:** the four post-review fixes in commit `d7b003b` (#38/#39/#40/#41)
+
+Originally scoped as 0.19.0 blocking work; released as 0.19.1 patch on top of the 0.19.0-pre baseline. PR #35 ships #44/#45/#47/#48/#49 together.
+
+## In-scope issues
+
+| # | Title | Effort | Risk |
+|---|-------|--------|------|
+| #44 | Drag-from-closed → Pinned / Auto-sort launches the terminal | 30 min | medium — touches the live-launch path |
+| #45 | Tile state matches terminal state after organizer drag (no offline ghost) | 20 min | low — synthetic status push, well-contained |
+| #47 | Revisit `isDropAllowed` — remove rejections the new model legitimizes | 15 min | low — single function, well-tested |
+| #48 | Pinned-closed policy: drop pin when a pinned tile's terminal exits | 10 min | low — one-line plus a behavior-change note |
+| #49 | Card runtime badge (live/closed) + drop-preview footer copy (**terse**) | 45 min | low — additive UI |
+
+Total estimate: **~2 hours of focused work + manual QA pass.**
+
+## Implementation order
+
+Order matters because some fixes change observable state that others depend on for testing.
+
+### Step 1 — #48 (pinned-closed policy + first-unpin notice) — test-first
+
+Pure state-machine change in `terminalTracker.ts`'s `onDidCloseTerminal` listener (already exists at line 106 per grep). Behavior: if the closed terminal's tile has `config.pinned === true`, call `configManager.setPinned(name, false)` before firing `onChange`.
+
+**First-auto-unpin notice** — on the first auto-unpin per workspace, show a non-modal toast:
+
+> `Pin removed for "X" because its terminal closed. Use autoStart to keep it pinned across restarts.`
+
+Actions: `[Don't show again]` (persists `seenPinClearedNotice: true`) and `[Open config]` (runs `claudeDashboard.openConfig`). Auto-dismiss the toast itself on any other interaction. Default `seenPinClearedNotice: false`; once flipped to `true`, never fires again in that workspace.
+
+**Test-first.** Four unit tests:
+1. Live + pinned tile + simulated `onDidCloseTerminal` → config has `pinned: false` after.
+2. Live + pinned + `autoStart: true` + close → `pinned: false` initially, then autoStart's launch path re-pins on next workspace open (asserts the autoStart story stays whole).
+3. First auto-unpin → notice helper invoked with the correct tile name.
+4. `seenPinClearedNotice: true` already set → notice helper NOT invoked on subsequent unpins.
+
+Manual: trigger the toast once, click `Don't show again`, trigger another unpin, verify silence.
+
+### Step 2 — #45 (tile state sync) — test-with-mocks then manual
+
+Needs a `markStarting(slug)` (or equivalent) on `terminalTracker` that synthetically pushes a non-offline status the moment a terminal is launched, before the first hook event arrives.
+
+**Test:** unit test asserting that the launch path emits a status transition out of `offline`/`registered` synchronously after `createTerminal`. Use the existing tracker test scaffolding.
+
+**Manual:** 10-second observation window after a drag-launched terminal — tile must never show offline. Match this against the inverse direction too: live → CBV via drag should leave the tile in CBV immediately, not show the old status briefly.
+
+Land this *before* #44 so the launch path #44 calls into already has the synthetic-status push baked in.
+
+### Step 3 — #44 (drag-from-closed launches) — implement then test
+
+Now the launch path is sync-correct. Wire `organizer.js` drop handler to dispatch a launch message when `dragSrc.isLive === false && (dstLane === 'pinned' || dstLane === 'auto')`.
+
+**Open question to resolve during impl:** what does the *current* drag-to-pinned actually do? User's #45 report says "drag-to-pinned opens the terminal" — but reading `organizer.js` + `applyOrganizerLayout` shows only a config flip, no launch dispatch. Possibilities:
+- The pinned bar tile click-to-launch handler is being triggered when the tile renders in its new lane (incidental, not intended).
+- An `autoStart: true` tile is launching on next render via the bar's autoStart hook.
+- The user misattributed terminal-open behavior to drag.
+
+The fix is the same regardless — explicit launch dispatch from the organizer when crossing into a Pinned/Auto lane from a non-live source. **Verify the actual current behavior at impl time** and either replace it with the explicit path or augment it.
+
+**Implementation sketch:**
+- `media/organizer.js` drop handler — detect launch-required drops, send `organizer:launchAndApply` message with `{ launchNames: [...], pinnedOrder, unpinnedNames, hiddenNames }`.
+- `src/organizerProvider.ts` — handle the new message: call existing launch path for each named slug, then `applyOrganizerLayout`.
+- Launch path may need a name-targeted variant; today `claudeDashboard.launchProject` opens an interactive picker. If no `launchByName(name: string)` exists, add it — small refactor of existing launch code.
+
+**Test:** unit test on the message handler asserting that closed → pinned drop produces the right `(launch, apply)` sequence. Manual integration test the full flow.
+
+### Step 4 — #47 (revisit isDropAllowed) — test-first
+
+With #44 in place, the only `isDropAllowed` rule today (`closedVisible → auto` is rejected per `organizer.js:30`) is now wrong — that drop should launch the terminal.
+
+**Test-first.** Rewrite the allow/deny matrix:
+- Same-lane drops: rejected.
+- All cross-lane drops: allowed. The runtime action (launch / dispose / config-only) is determined by destination per the #46 drop-semantics table.
+
+Remove `rejectionReason()` text for `closedVisible → auto` — replaced by drop-preview in #49.
+
+### Step 5 — #49 (card badge + drop-preview footer, terse) — implement then visual QA
+
+Two additive UI pieces:
+
+**Card runtime badge** — small dot on every card based on `Card.isLive`. Live = green; closed = grey. Render in initial draw and diff-update paths in `organizer.js`.
+
+**Drop-preview footer (terse copy)** — on `dragover` of a valid target lane, footer shows the action verb + target name. Resolved at decision: terse over descriptive.
+
+| Source → Dest | Preview |
+|---------------|---------|
+| closed → pinned | `Launch + pin X` |
+| closed → auto | `Launch X` |
+| live → closedVisible | `Close X` |
+| any → hidden | `Hide X` |
+| hidden → auto | `Unhide X` (or `Unhide + launch X` if was closed) |
+| hidden → pinned | `Unhide + pin X` (or `Unhide + launch + pin X` if was closed) |
+| pinned → auto | `Unpin X` |
+
+Clears on `dragleave` / `dragend`. Reuses the existing footer-status slot (which today shows the rejection text).
+
+**Test:** light unit test on the preview-text resolver (pure function). The DOM rendering is best caught via manual QA.
+
+## Untested elements from prior 0.19 work that are still relevant
+
+These items are flagged in the 2026-05-09 session log follow-ups or implied by the d7b003b commit but were never explicitly tested. Most can be folded into the 0.19.0 patch since the test files are already being touched.
+
+### 1. `hotkey` field round-trip through `generateConfigText`
+
+**Status:** untested. Session log notes the field is round-tripped via `JSON.stringify` but not explicitly emitted by `generateConfigText`. Could silently drop on first save.
+
+**Recommendation:** **add test in 0.19.0.** ~5-line round-trip test (set hotkey → save → reload → assert field preserved).
+
+### 2. `confirmCloseOnDrop: false` persistence
+
+**Status:** unit-tested per d7b003b but only at the setter level. Whether the field round-trips through a config-file rewrite cleanly is implied, not asserted.
+
+**Recommendation:** **add test in 0.19.0.** Same shape as #1.
+
+### 3. Organizer panel disposal / reopen lifecycle
+
+**Status:** the d7b003b fix tracked `onDidReceiveMessage` in `subDisposables`. No test asserts that re-opening the panel after close doesn't create duplicate handlers.
+
+**Recommendation:** **add test in 0.19.0.** Open + dispose + reopen + send a message → assert single response (no double-fire).
+
+### 4. Mid-drag re-render buffering (`pendingState`)
+
+**Status:** logic landed in d7b003b. Hard to unit-test (real DnD). The bug it fixes is silent if it regresses.
+
+**Recommendation:** **manual QA in 0.19.0**, not a new test. Specific test step: drag a tile slowly while a status-file change is mid-flight; verify the drop completes correctly. Document the manual step in the PR test plan.
+
+### 5. Prototype pollution boundary
+
+**Status:** unit tests cover `__proto__`, `constructor`, `prototype` keys. No tests for adjacent attack shapes (deep-nested keys, array indices, Unicode lookalikes).
+
+**Recommendation:** **defer — adequate as shipped.** The boundary is `applyOrganizerLayout` accepting only name strings from the webview. The webview is extension-controlled today. Revisit if external IPC ever opens up.
+
+### 6. `sortMode` flip from manual → auto after non-pinned wipe
+
+**Status:** asserted in d7b003b's tests for `applyOrganizerLayout`, but not for the user-observable consequence (bar's order matches panel's display after a drag in manual mode).
+
+**Recommendation:** **manual QA in 0.19.0.** One test step: set sortMode=manual, drag a non-pinned tile in the organizer, verify the bar reorders to match.
+
+### 7. Cross-platform organizer panel rendering
+
+**Status:** built and reviewed on Linux/WSL. Windows-specific behavior already surfaced in #54 (audio). No reason to expect organizer rendering issues, but worth a single Windows smoke-test pass.
+
+**Recommendation:** **manual QA in 0.19.0.** User runs PR test plan on their Windows work environment.
+
+### 8. Pre-existing TypeScript errors on `main`
+
+**Status:** flagged in 2026-05-09 session log — `configManager.ts:302/365`, `extension.ts:339`, `wizard.ts:396`. Not introduced by this work; pre-existed.
+
+**Recommendation:** **separate cleanup branch, not 0.19.0.** Don't mix unrelated noise into the refactor diff. File as a chore issue, fix in a 0.19.1 chore commit.
+
+## Risks
+
+- **#44's launch-path verification** — actual current behavior of drag-to-pinned is uncertain (see Step 3 open question). Could discover at impl time that there's a hidden side-effect path that needs unwinding before the explicit one can land cleanly.
+- **#48's user-visible behavior change** — pinned tiles losing their pin on terminal exit will surprise users who relied on pin-as-persistent. Mitigation: changelog entry + first-auto-unpin toast (see Step 1) that fires at the moment of confusion and points to `autoStart`.
+- **#49's footer copy collision with #41's confirmation modal** — when drop-preview says `Close X` and then the modal fires, the messaging is redundant. Acceptable redundancy — the preview is the *announcement* and the modal is the *gate*. Verify in QA that it doesn't feel like nag.
+- **Scope creep on #49** — the badge + footer can easily expand into "while we're touching cards, let's add the live/closed icons everywhere." Hold the line: only the badge dot and the footer text in 0.19.0. Per-card buttons are #50, polished separately.
+
+## Release checklist
+
+- [ ] Implement steps 1–5 above in order, with the recommended tests
+- [ ] Add the 3 round-trip / lifecycle tests from "untested elements" §1, §2, §3
+- [ ] Manual QA pass covering §4 (mid-drag), §6 (sortMode flip), §7 (Windows smoke)
+- [ ] Update `.claudelike-bar.jsonc` schema docs if `confirmCloseOnDrop` or `hotkey` fields need a docs pass (added in 0.19 without README updates)
+- [ ] Changelog entry: include the pinned-closed behavior change as a "BREAKING (sort of) — pin no longer persists across terminal exit; use `autoStart` for that"
+- [ ] Bump `package.json` to `0.19.0` (drop `-pre` suffix)
+- [ ] Repackage VSIX, publish to Open VSX + Marketplace
+
+## Out of scope (deferred to 0.19.x / 0.20)
+
+Tracked but not shipping with 0.19.0:
+
+- **#50** per-card launch/close button — pairs naturally with #49 but each is independently shippable
+- **#51** "pure config" view toggle — meaningful UI work; aim for 0.20
+- **#52** orphan detection — small feature but unrelated to drag model
+- **#53** last-active timestamp on CBV — requires persistence decision
+- **#33** audio chime drops + **#54** audio queue-burst on Windows — both need diagnostic logging (audio.log mirror) before a real fix
+- **#43** terminals opened fresh show used context — separate root cause
+- **#42** drag lane headers to reorder zones — feature request
+- **Backlog: subagent counter drift** — root cause documented; recommended fix is small but lives in its own patch
+
+## Resolved decisions
+
+- **Scope** — refactor is release-blocking for 0.19.0 (not deferred to 0.19.1).
+- **#49 footer copy** — terse verb+name format (`Launch X`, `Close X`, `Hide X`) over descriptive long-form.
+- **#48 first-auto-unpin notification** — show a one-time per-workspace toast on first auto-unpin, pointing to `autoStart`, with `[Don't show again]` + `[Open config]` actions. Persisted via `seenPinClearedNotice: boolean` on config.

--- a/media/organizer.css
+++ b/media/organizer.css
@@ -1,0 +1,185 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--vscode-font-family);
+  font-size: var(--vscode-font-size);
+  color: var(--vscode-foreground);
+  background: var(--vscode-editor-background);
+  padding: 16px 20px 12px;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.organizer-header h1 {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.organizer-header .hint {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  margin-bottom: 14px;
+  line-height: 1.5;
+}
+
+.lanes {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(180px, 1fr));
+  gap: 12px;
+  flex: 1;
+  min-height: 0;
+}
+
+.lane {
+  display: flex;
+  flex-direction: column;
+  background: var(--vscode-sideBar-background, rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: 4px;
+  min-height: 0;
+}
+
+.lane > header {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--vscode-panel-border);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--vscode-editorGroupHeader-tabsBackground, transparent);
+}
+
+.lane-title {
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.lane-sub {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  line-height: 1.4;
+}
+
+.cards {
+  flex: 1;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+  min-height: 80px;
+}
+
+.cards.empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.cards .empty-msg {
+  color: var(--vscode-descriptionForeground);
+  font-size: 11px;
+  text-align: center;
+  padding: 12px 8px;
+  font-style: italic;
+  pointer-events: none;
+}
+
+/* Drop highlight on droppable lanes only. */
+.cards[data-droppable="true"].drag-over {
+  background: var(--vscode-list-dropBackground, rgba(100, 150, 255, 0.08));
+  outline: 1px dashed var(--vscode-focusBorder);
+  outline-offset: -2px;
+}
+
+/* The passive lane (closed-visible) gets a subtle "no-drop" cursor when
+   something is being dragged over it. We don't outline it — passive means
+   silent reject, not a flashy error. */
+.cards[data-droppable="false"].drag-over {
+  cursor: not-allowed;
+}
+
+.card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--vscode-editor-background);
+  border: 1px solid var(--vscode-panel-border);
+  border-left: 4px solid var(--card-color, var(--vscode-panel-border));
+  border-radius: 3px;
+  cursor: grab;
+  font-size: 12px;
+  user-select: none;
+  transition: background 0.12s ease, opacity 0.2s ease;
+}
+
+.card:hover {
+  background: var(--vscode-list-hoverBackground);
+}
+
+.card.dragging {
+  opacity: 0.35;
+  cursor: grabbing;
+}
+
+.card.drop-before {
+  box-shadow: 0 -2px 0 0 var(--vscode-focusBorder);
+}
+
+.card.drop-after {
+  box-shadow: 0 2px 0 0 var(--vscode-focusBorder);
+}
+
+.card .card-icon {
+  font-size: 13px;
+  color: var(--card-color);
+  width: 14px;
+  text-align: center;
+}
+
+.card .card-name {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card .shell-tag {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 8px;
+  background: var(--vscode-badge-background);
+  color: var(--vscode-badge-foreground);
+  text-transform: uppercase;
+}
+
+.organizer-footer {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.organizer-footer button {
+  padding: 4px 10px;
+  font-size: 11px;
+  color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+  background: var(--vscode-button-secondaryBackground, var(--vscode-button-background));
+  border: none;
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.organizer-footer button:hover {
+  background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-hoverBackground));
+}
+
+.organizer-footer .status {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+}

--- a/media/organizer.css
+++ b/media/organizer.css
@@ -96,10 +96,10 @@ body {
   outline-offset: -2px;
 }
 
-/* The passive lane (closed-visible) gets a subtle "no-drop" cursor when
-   something is being dragged over it. We don't outline it — passive means
-   silent reject, not a flashy error. */
-.cards[data-droppable="false"].drag-over {
+/* Any lane that rejects the current drop (e.g. closedVisible → auto for a
+   non-live tile) gets a "no-drop" cursor while the cursor hovers over it.
+   The footer status surfaces the reason — see issue #41. */
+.cards.drop-rejected.drag-over {
   cursor: not-allowed;
 }
 

--- a/media/organizer.css
+++ b/media/organizer.css
@@ -96,13 +96,6 @@ body {
   outline-offset: -2px;
 }
 
-/* Any lane that rejects the current drop (e.g. closedVisible → auto for a
-   non-live tile) gets a "no-drop" cursor while the cursor hovers over it.
-   The footer status surfaces the reason — see issue #41. */
-.cards.drop-rejected.drag-over {
-  cursor: not-allowed;
-}
-
 .card {
   display: flex;
   align-items: center;
@@ -156,6 +149,27 @@ body {
   background: var(--vscode-badge-background);
   color: var(--vscode-badge-foreground);
   text-transform: uppercase;
+}
+
+/* v0.19 (#49) — runtime status dot on every card. Live = green; closed =
+   neutral grey. Renders to the right of the name, before any other badge.
+   The dot makes the runtime axis visible so users see, before dragging,
+   which axis a drop will cross (config-only vs runtime-mutating). */
+.card .live-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
+.card .live-dot.live {
+  background: var(--vscode-testing-iconPassed, #4ec9b0);
+  box-shadow: 0 0 0 1px var(--vscode-editor-background) inset;
+}
+
+.card .live-dot.closed {
+  background: var(--vscode-descriptionForeground);
+  opacity: 0.45;
 }
 
 .organizer-footer {

--- a/media/organizer.js
+++ b/media/organizer.js
@@ -21,23 +21,63 @@
     hidden: true,
   };
 
-  // closedVisible → auto is a no-op at the config layer (both lanes share
-  // `pinned:false, hidden:false`; the only difference is runtime liveness).
-  // Without this guard the drop appears to succeed then snaps back when the
-  // next state push re-derives the lane from `liveNames` — see issue #38.
+  // v0.19 (#47) — under the target-state model (#46), every cross-lane drop
+  // is meaningful. The destination's runtime requirement (live vs closed)
+  // determines whether the drop also triggers a launch (#44) or a close
+  // (#41); the config flip happens regardless. The earlier blanket
+  // rejection on `closedVisible → auto` (#38) was the symptom of trying to
+  // suppress a runtime-required drop instead of executing it — it now
+  // launches the terminal, satisfying Auto-sort's "live tiles only" rule.
+  //
+  // The only invalid drop is one whose destination isn't a real lane
+  // (defensive against a future fifth lane key arriving in a stale state).
   function isDropAllowed(srcLane, dstLane) {
     if (!DROPPABLE[dstLane]) return false;
-    if (srcLane === 'closedVisible' && dstLane === 'auto') return false;
+    // Same lane + no position metadata = nothing-to-do drops (the in-lane
+    // reorder handler already short-circuits the "drop on self" case via
+    // moveCard's position.relative === name check).
+    if (srcLane === dstLane) return true;
     return true;
   }
 
-  // Plain-language reason for a rejected drop — surfaced in the footer
-  // status so the user knows *why* nothing happened (issue #41).
-  function rejectionReason(srcLane, dstLane) {
-    if (srcLane === 'closedVisible' && dstLane === 'auto') {
-      return 'Auto-sort shows running tiles only — launch the tile to move it here.';
+  // v0.19 (#49) — drop-preview footer copy. Pure function so behavior is
+  // self-evident and the table reads as a spec: source lane × destination
+  // lane × runtime liveness → terse verb-and-name announcement of what
+  // the drop will do. Returns null when the drop is a no-op (same lane,
+  // same position) — the footer stays empty.
+  //
+  // Terse over descriptive per the 0.19.0 plan: "Launch X" reads at a
+  // glance while dragging, where "Drop here to launch project X" is
+  // visual noise once the convention is known.
+  function dropPreview(srcLane, dstLane, srcIsLive, name) {
+    if (!srcLane || !dstLane || !name) return null;
+    if (srcLane === dstLane) return null;
+    if (dstLane === 'pinned') {
+      if (srcLane === 'hidden') return srcIsLive ? `Unhide + pin ${name}` : `Unhide + launch + pin ${name}`;
+      if (srcLane === 'closedVisible') return `Launch + pin ${name}`;
+      return `Pin ${name}`;
+    }
+    if (dstLane === 'auto') {
+      if (srcLane === 'hidden') return srcIsLive ? `Unhide ${name}` : `Unhide + launch ${name}`;
+      if (srcLane === 'closedVisible') return `Launch ${name}`;
+      if (srcLane === 'pinned') return `Unpin ${name}`;
+      return null;
+    }
+    if (dstLane === 'closedVisible') {
+      if (srcIsLive) return `Close ${name}`;
+      if (srcLane === 'pinned') return `Unpin ${name}`;
+      if (srcLane === 'hidden') return `Unhide ${name}`;
+      return null;
+    }
+    if (dstLane === 'hidden') {
+      return `Hide ${name}`;
     }
     return null;
+  }
+  // Exported on globalThis for the syntax-guard / future unit access.
+  // Webview script is an IIFE; this is the only escape hatch.
+  if (typeof globalThis !== 'undefined') {
+    globalThis.__organizerDropPreview = dropPreview;
   }
 
   let state = {
@@ -55,9 +95,14 @@
   // Most recent organizer:state message arrived during a drag — applied in
   // dragend so the in-flight drop isn't clobbered by a mid-drag rebuild.
   let pendingState = null;
-  // True while the footer shows a drop-rejection reason — cleared on
-  // dragend if the drop didn't land somewhere successful (issue #41).
-  let rejectionShown = false;
+  // v0.19 (#49) — true while the footer shows a drop-preview message
+  // (e.g. "Launch foo"). Cleared on dragend / dragleave / successful drop.
+  let previewShown = false;
+  // v0.19 — cache of the preview string most recently rendered to the
+  // footer. The lane-level dragover handler fires at ~60fps; without this
+  // guard each frame would burn a setStatus() DOM write and a template-
+  // literal allocation even though the action text hasn't changed.
+  let lastPreview = null;
 
   function laneEl(key) {
     return document.querySelector(`.lane[data-lane="${key}"] .cards`);
@@ -114,6 +159,14 @@
       : `${card.displayName} (${card.name})`;
     el.appendChild(name);
 
+    // v0.19 (#49) — runtime status dot. Green when the terminal is live,
+    // grey when closed. Renders on every card so users see the runtime
+    // axis at a glance, before deciding to drag.
+    const dot = document.createElement('span');
+    dot.className = `live-dot ${card.isLive ? 'live' : 'closed'}`;
+    dot.title = card.isLive ? 'Terminal running' : 'Terminal closed';
+    el.appendChild(dot);
+
     if (card.isShell) {
       const tag = document.createElement('span');
       tag.className = 'shell-tag';
@@ -122,7 +175,15 @@
     }
 
     el.addEventListener('dragstart', (e) => {
-      dragSrc = { name: card.name, lane };
+      // v0.19 (#49) — carry the runtime liveness + display name so the
+      // drop-preview footer can announce what each drop will do without
+      // re-finding the card on every dragover.
+      dragSrc = {
+        name: card.name,
+        lane,
+        isLive: !!card.isLive,
+        displayName: card.displayName,
+      };
       el.classList.add('dragging');
       e.dataTransfer.effectAllowed = 'move';
       // setData is required for drag to fire in some browsers/webviews.
@@ -136,14 +197,17 @@
         currentDropTarget.classList.remove('drop-before', 'drop-after');
         currentDropTarget = null;
       }
-      document.querySelectorAll('.cards.drag-over, .cards.drop-rejected')
-        .forEach((c) => c.classList.remove('drag-over', 'drop-rejected'));
-      // Clear a lingering rejection-reason status if the drop didn't land
-      // somewhere successful (a successful drop replaces it with 'Saved.').
-      if (rejectionShown) {
+      document.querySelectorAll('.cards.drag-over')
+        .forEach((c) => c.classList.remove('drag-over'));
+      // Clear a lingering drop-preview status when the drop ends without
+      // landing on a target (drop on an invalid spot, Escape, etc.). A
+      // successful drop replaces it with 'Saved.' or 'Launching…' via
+      // sendLayout.
+      if (previewShown) {
         setStatus('', false);
-        rejectionShown = false;
+        previewShown = false;
       }
+      lastPreview = null;
       // Apply any state update that arrived during the drag — we deferred
       // it so the dragged DOM node wouldn't get clobbered mid-gesture.
       if (pendingState) {
@@ -201,34 +265,33 @@
       if (!container) continue;
       container.addEventListener('dragover', (e) => {
         if (!dragSrc) return;
-        if (!isDropAllowed(dragSrc.lane, key)) {
-          // Visually flag the rejection but don't preventDefault — the drop
-          // will be ignored by the browser since we never accept it. Covers
-          // the closedVisible → auto no-op case (issue #38). Surface a
-          // plain-language reason in the footer (issue #41).
-          container.classList.add('drag-over', 'drop-rejected');
-          const reason = rejectionReason(dragSrc.lane, key);
-          if (reason) {
-            setStatus(reason, false);
-            rejectionShown = true;
-          }
-          return;
-        }
+        if (!isDropAllowed(dragSrc.lane, key)) return;
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
         container.classList.add('drag-over');
-        container.classList.remove('drop-rejected');
+        // v0.19 (#49) — announce the action this drop will take. Terse
+        // verb+name format keeps the footer scannable while dragging.
+        // Cache the last computed preview string so the 60fps dragover
+        // doesn't burn a setStatus() DOM write every frame — only update
+        // when the preview text actually changes.
+        const preview = dropPreview(dragSrc.lane, key, dragSrc.isLive, dragSrc.displayName);
+        if (preview && preview !== lastPreview) {
+          setStatus(preview, false);
+          previewShown = true;
+          lastPreview = preview;
+        }
       });
       container.addEventListener('dragleave', (e) => {
         // Only clear when leaving the container (not when crossing into a
         // child card). relatedTarget is the element we're entering.
         if (e.relatedTarget && container.contains(e.relatedTarget)) return;
-        container.classList.remove('drag-over', 'drop-rejected');
-        // Clear the rejection status when the cursor leaves the rejected
-        // lane — keeps the footer accurate as the user keeps dragging.
-        if (rejectionShown && !isDropAllowed(dragSrc?.lane, key)) {
+        container.classList.remove('drag-over');
+        // Clear the preview text when the cursor leaves the lane — the
+        // next lane the user hovers will set its own preview.
+        if (previewShown) {
           setStatus('', false);
-          rejectionShown = false;
+          previewShown = false;
+          lastPreview = null;
         }
       });
       container.addEventListener('drop', (e) => {
@@ -273,6 +336,14 @@
       return;
     }
 
+    // v0.19 (#44) — closed (non-live) tile dropped into Pinned or Auto-sort:
+    // the destination lane requires a live terminal, so the same drop is also
+    // a launch request. Build the launch list before mutating local state.
+    const launchNames = [];
+    if (!sourceCard.isLive && (dstLane === 'pinned' || dstLane === 'auto')) {
+      launchNames.push(sourceCard.name);
+    }
+
     // Remove from source lane.
     const [card] = srcArr.splice(idx, 1);
 
@@ -289,11 +360,20 @@
       dstArr.push(card);
     }
 
+    // Optimistic: flip the card's local isLive so the post-render
+    // matches the user's destination lane. The next state push from the
+    // extension is authoritative — if the launch fails for any reason,
+    // it'll correct us. Better than rendering a "closed" badge on a card
+    // that just initiated a launch.
+    if (launchNames.length > 0) {
+      card.isLive = true;
+    }
+
     render();
-    sendLayout();
+    sendLayout(launchNames);
   }
 
-  function sendLayout() {
+  function sendLayout(launchNames) {
     vscode.postMessage({
       type: 'organizer:applyLayout',
       pinnedOrder: state.pinned.map((c) => c.name),
@@ -301,8 +381,15 @@
       // runtime liveness is the only difference. Send them as one list.
       unpinnedNames: [...state.auto, ...state.closedVisible].map((c) => c.name),
       hiddenNames: state.hidden.map((c) => c.name),
+      // v0.19 (#44) — names to launch as part of this drop. Provider runs
+      // launches AFTER applyLayout so the destination lane's config flags
+      // are set when the terminal opens.
+      launchNames: Array.isArray(launchNames) ? launchNames : [],
     });
-    setStatus('Saved.', true);
+    setStatus(
+      (launchNames && launchNames.length) ? 'Launching…' : 'Saved.',
+      true,
+    );
   }
 
   function setStatus(text, transient) {

--- a/media/organizer.js
+++ b/media/organizer.js
@@ -1,0 +1,288 @@
+// @ts-nocheck
+/* Tile-organizer panel — vanilla JS, native HTML5 drag/drop, no deps.
+   The webview owns the lane layout; on drop, we ship the full picture
+   (pinnedOrder, unpinnedNames, hiddenNames) back to the extension which
+   applies it atomically through ConfigManager.applyOrganizerLayout. */
+(function () {
+  const vscode = acquireVsCodeApi();
+
+  // Lane keys map to the data-lane attributes in organizer.html.
+  const LANE_KEYS = ['pinned', 'auto', 'closedVisible', 'hidden'];
+
+  // Whether each lane accepts drops. closedVisible is passive — tiles auto-
+  // appear there when their terminal exits and you can't drag into it.
+  const DROPPABLE = {
+    pinned: true,
+    auto: true,
+    closedVisible: false,
+    hidden: true,
+  };
+
+  let state = {
+    pinned: [],
+    auto: [],
+    closedVisible: [],
+    hidden: [],
+  };
+
+  let dragSrc = null; // { name, lane } of the card being dragged
+  // Element currently showing a drop-before/drop-after placeholder. Cached
+  // so dragover (60fps hot path) can clear the prior indicator with a
+  // single classList op instead of a document-wide querySelectorAll.
+  let currentDropTarget = null;
+  // Most recent organizer:state message arrived during a drag — applied in
+  // dragend so the in-flight drop isn't clobbered by a mid-drag rebuild.
+  let pendingState = null;
+
+  function laneEl(key) {
+    return document.querySelector(`.lane[data-lane="${key}"] .cards`);
+  }
+
+  function render() {
+    for (const key of LANE_KEYS) {
+      const container = laneEl(key);
+      if (!container) continue;
+      container.innerHTML = '';
+      const cards = state[key] || [];
+      if (cards.length === 0) {
+        container.classList.add('empty');
+        const empty = document.createElement('div');
+        empty.className = 'empty-msg';
+        empty.textContent = laneEmptyHint(key);
+        container.appendChild(empty);
+      } else {
+        container.classList.remove('empty');
+        for (const card of cards) {
+          container.appendChild(makeCardEl(card, key));
+        }
+      }
+    }
+  }
+
+  function laneEmptyHint(key) {
+    if (key === 'pinned') return 'Drag tiles here to pin them at the bar bottom.';
+    if (key === 'auto') return 'No running tiles — open a Claude terminal to populate.';
+    if (key === 'closedVisible') return 'No registered tiles waiting for launch.';
+    if (key === 'hidden') return 'Drag tiles here to hide them from the bar.';
+    return '';
+  }
+
+  function makeCardEl(card, lane) {
+    const el = document.createElement('div');
+    el.className = 'card';
+    el.draggable = true;
+    el.dataset.name = card.name;
+    el.dataset.lane = lane;
+    el.style.setProperty('--card-color', card.themeColor);
+
+    const icon = document.createElement('span');
+    icon.className = 'card-icon codicon';
+    if (card.icon) icon.classList.add(`codicon-${card.icon}`);
+    else icon.classList.add('codicon-terminal');
+    el.appendChild(icon);
+
+    const name = document.createElement('span');
+    name.className = 'card-name';
+    name.textContent = card.displayName;
+    name.title = card.name === card.displayName
+      ? card.name
+      : `${card.displayName} (${card.name})`;
+    el.appendChild(name);
+
+    if (card.isShell) {
+      const tag = document.createElement('span');
+      tag.className = 'shell-tag';
+      tag.textContent = 'shell';
+      el.appendChild(tag);
+    }
+
+    el.addEventListener('dragstart', (e) => {
+      dragSrc = { name: card.name, lane };
+      el.classList.add('dragging');
+      e.dataTransfer.effectAllowed = 'move';
+      // setData is required for drag to fire in some browsers/webviews.
+      try { e.dataTransfer.setData('text/plain', card.name); } catch (_) {}
+    });
+    el.addEventListener('dragend', () => {
+      el.classList.remove('dragging');
+      dragSrc = null;
+      // Cleanup any lingering placeholders.
+      if (currentDropTarget) {
+        currentDropTarget.classList.remove('drop-before', 'drop-after');
+        currentDropTarget = null;
+      }
+      document.querySelectorAll('.cards.drag-over')
+        .forEach((c) => c.classList.remove('drag-over'));
+      // Apply any state update that arrived during the drag — we deferred
+      // it so the dragged DOM node wouldn't get clobbered mid-gesture.
+      if (pendingState) {
+        const next = pendingState;
+        pendingState = null;
+        applyState(next);
+      }
+    });
+
+    // Within-lane reorder: card-level dragover marks before/after.
+    el.addEventListener('dragover', (e) => {
+      if (!dragSrc) return;
+      const targetLaneKey = el.dataset.lane;
+      if (!DROPPABLE[targetLaneKey]) return;
+      // Auto-sort lane has no persisted order — within-lane reorder is a
+      // no-op there, so don't draw the placeholder. Cross-lane drops still
+      // work via the lane-container dragover handler.
+      if (targetLaneKey === 'auto') return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      const rect = el.getBoundingClientRect();
+      const before = (e.clientY - rect.top) < rect.height / 2;
+      // Clear the prior indicator (if any) and mark this one. Single
+      // classList op per move beats a document-wide query at 60fps.
+      if (currentDropTarget && currentDropTarget !== el) {
+        currentDropTarget.classList.remove('drop-before', 'drop-after');
+      } else if (currentDropTarget === el) {
+        // Same target as last frame — only flip the before/after side if
+        // the cursor crossed the midline.
+        el.classList.remove('drop-before', 'drop-after');
+      }
+      el.classList.add(before ? 'drop-before' : 'drop-after');
+      currentDropTarget = el;
+    });
+    el.addEventListener('drop', (e) => {
+      if (!dragSrc) return;
+      const targetLaneKey = el.dataset.lane;
+      if (!DROPPABLE[targetLaneKey]) return;
+      if (targetLaneKey === 'auto') return; // fall through to lane-level drop
+      e.preventDefault();
+      e.stopPropagation();
+      const before = el.classList.contains('drop-before');
+      const targetName = el.dataset.name;
+      moveCard(dragSrc.name, dragSrc.lane, targetLaneKey, { relative: targetName, before });
+    });
+
+    return el;
+  }
+
+  // Lane-level drop handlers — for drops onto empty space inside a lane,
+  // and for lanes where intra-lane order isn't tracked (auto-sort).
+  function wireLaneContainers() {
+    for (const key of LANE_KEYS) {
+      const container = laneEl(key);
+      if (!container) continue;
+      container.addEventListener('dragover', (e) => {
+        if (!dragSrc) return;
+        if (!DROPPABLE[key]) {
+          // Visually flag the rejection but don't preventDefault — the drop
+          // will be ignored by the browser since we never accept it.
+          container.classList.add('drag-over');
+          return;
+        }
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        container.classList.add('drag-over');
+      });
+      container.addEventListener('dragleave', (e) => {
+        // Only clear when leaving the container (not when crossing into a
+        // child card). relatedTarget is the element we're entering.
+        if (e.relatedTarget && container.contains(e.relatedTarget)) return;
+        container.classList.remove('drag-over');
+      });
+      container.addEventListener('drop', (e) => {
+        if (!dragSrc) return;
+        container.classList.remove('drag-over');
+        if (!DROPPABLE[key]) return;
+        // If a child card already handled this drop, bail — its handler
+        // calls stopPropagation(). This branch covers empty-lane drops and
+        // drops past the last card in a lane.
+        e.preventDefault();
+        moveCard(dragSrc.name, dragSrc.lane, key, { append: true });
+      });
+    }
+  }
+
+  // Apply a move to the local state, then ship the full layout to the host.
+  function moveCard(name, srcLane, dstLane, position) {
+    if (!srcLane || !dstLane) return;
+    if (!DROPPABLE[dstLane]) return;
+    if (srcLane === dstLane && position && position.relative === name) return;
+
+    // Remove from source lane.
+    const srcArr = state[srcLane];
+    const idx = srcArr.findIndex((c) => c.name === name);
+    if (idx === -1) return;
+    const [card] = srcArr.splice(idx, 1);
+
+    // Apply card stamp changes for cross-lane moves so the immediate render
+    // reflects the new lane (e.g. shell tag still renders, color persists).
+    const dstArr = state[dstLane];
+    if (position && position.relative) {
+      const targetIdx = dstArr.findIndex((c) => c.name === position.relative);
+      const insertAt = targetIdx === -1
+        ? dstArr.length
+        : (position.before ? targetIdx : targetIdx + 1);
+      dstArr.splice(insertAt, 0, card);
+    } else {
+      dstArr.push(card);
+    }
+
+    render();
+    sendLayout();
+  }
+
+  function sendLayout() {
+    vscode.postMessage({
+      type: 'organizer:applyLayout',
+      pinnedOrder: state.pinned.map((c) => c.name),
+      // Auto-sort + closed-but-visible share config state — same flag combo,
+      // runtime liveness is the only difference. Send them as one list.
+      unpinnedNames: [...state.auto, ...state.closedVisible].map((c) => c.name),
+      hiddenNames: state.hidden.map((c) => c.name),
+    });
+    setStatus('Saved.', true);
+  }
+
+  function setStatus(text, transient) {
+    const el = document.getElementById('status');
+    if (!el) return;
+    el.textContent = text;
+    if (transient) {
+      setTimeout(() => {
+        if (el.textContent === text) el.textContent = '';
+      }, 1500);
+    }
+  }
+
+  // Footer button: open the JSONC config in an editor.
+  document.querySelector('button[data-action="openConfig"]')?.addEventListener('click', () => {
+    vscode.postMessage({ type: 'organizer:openConfig' });
+  });
+
+  function applyState(msg) {
+    state = {
+      pinned: Array.isArray(msg.lanes?.pinned) ? msg.lanes.pinned : [],
+      auto: Array.isArray(msg.lanes?.auto) ? msg.lanes.auto : [],
+      closedVisible: Array.isArray(msg.lanes?.closedVisible) ? msg.lanes.closedVisible : [],
+      hidden: Array.isArray(msg.lanes?.hidden) ? msg.lanes.hidden : [],
+    };
+    render();
+  }
+
+  window.addEventListener('message', (e) => {
+    const msg = e.data;
+    if (!msg || msg.type !== 'organizer:state') return;
+    // Defer rebuilds while the user has a card grabbed — innerHTML='' on
+    // the lane container would detach the dragged DOM node mid-gesture
+    // and silently abort the HTML5 drag operation. dragend applies the
+    // pending state once the drop completes.
+    if (dragSrc) {
+      pendingState = msg;
+      return;
+    }
+    applyState(msg);
+  });
+
+  wireLaneContainers();
+  // Render once with whatever's in the (initially empty) state, then ask for
+  // the real picture. Avoids a flash of stale empty lanes.
+  render();
+  vscode.postMessage({ type: 'organizer:requestState' });
+})();

--- a/media/organizer.js
+++ b/media/organizer.js
@@ -9,14 +9,36 @@
   // Lane keys map to the data-lane attributes in organizer.html.
   const LANE_KEYS = ['pinned', 'auto', 'closedVisible', 'hidden'];
 
-  // Whether each lane accepts drops. closedVisible is passive — tiles auto-
-  // appear there when their terminal exits and you can't drag into it.
+  // Whether each lane accepts drops. closedVisible is no longer passive —
+  // dropping a live tile there asks the extension to close the terminal
+  // (with an optional confirmation modal). Dropping a non-live tile from
+  // pinned/hidden into closedVisible is a config-only flag clear, routed
+  // through the same applyLayout pipeline as a drop into auto-sort.
   const DROPPABLE = {
     pinned: true,
     auto: true,
-    closedVisible: false,
+    closedVisible: true,
     hidden: true,
   };
+
+  // closedVisible → auto is a no-op at the config layer (both lanes share
+  // `pinned:false, hidden:false`; the only difference is runtime liveness).
+  // Without this guard the drop appears to succeed then snaps back when the
+  // next state push re-derives the lane from `liveNames` — see issue #38.
+  function isDropAllowed(srcLane, dstLane) {
+    if (!DROPPABLE[dstLane]) return false;
+    if (srcLane === 'closedVisible' && dstLane === 'auto') return false;
+    return true;
+  }
+
+  // Plain-language reason for a rejected drop — surfaced in the footer
+  // status so the user knows *why* nothing happened (issue #41).
+  function rejectionReason(srcLane, dstLane) {
+    if (srcLane === 'closedVisible' && dstLane === 'auto') {
+      return 'Auto-sort shows running tiles only — launch the tile to move it here.';
+    }
+    return null;
+  }
 
   let state = {
     pinned: [],
@@ -33,6 +55,9 @@
   // Most recent organizer:state message arrived during a drag — applied in
   // dragend so the in-flight drop isn't clobbered by a mid-drag rebuild.
   let pendingState = null;
+  // True while the footer shows a drop-rejection reason — cleared on
+  // dragend if the drop didn't land somewhere successful (issue #41).
+  let rejectionShown = false;
 
   function laneEl(key) {
     return document.querySelector(`.lane[data-lane="${key}"] .cards`);
@@ -111,8 +136,14 @@
         currentDropTarget.classList.remove('drop-before', 'drop-after');
         currentDropTarget = null;
       }
-      document.querySelectorAll('.cards.drag-over')
-        .forEach((c) => c.classList.remove('drag-over'));
+      document.querySelectorAll('.cards.drag-over, .cards.drop-rejected')
+        .forEach((c) => c.classList.remove('drag-over', 'drop-rejected'));
+      // Clear a lingering rejection-reason status if the drop didn't land
+      // somewhere successful (a successful drop replaces it with 'Saved.').
+      if (rejectionShown) {
+        setStatus('', false);
+        rejectionShown = false;
+      }
       // Apply any state update that arrived during the drag — we deferred
       // it so the dragged DOM node wouldn't get clobbered mid-gesture.
       if (pendingState) {
@@ -126,7 +157,7 @@
     el.addEventListener('dragover', (e) => {
       if (!dragSrc) return;
       const targetLaneKey = el.dataset.lane;
-      if (!DROPPABLE[targetLaneKey]) return;
+      if (!isDropAllowed(dragSrc.lane, targetLaneKey)) return;
       // Auto-sort lane has no persisted order — within-lane reorder is a
       // no-op there, so don't draw the placeholder. Cross-lane drops still
       // work via the lane-container dragover handler.
@@ -150,7 +181,7 @@
     el.addEventListener('drop', (e) => {
       if (!dragSrc) return;
       const targetLaneKey = el.dataset.lane;
-      if (!DROPPABLE[targetLaneKey]) return;
+      if (!isDropAllowed(dragSrc.lane, targetLaneKey)) return;
       if (targetLaneKey === 'auto') return; // fall through to lane-level drop
       e.preventDefault();
       e.stopPropagation();
@@ -170,26 +201,40 @@
       if (!container) continue;
       container.addEventListener('dragover', (e) => {
         if (!dragSrc) return;
-        if (!DROPPABLE[key]) {
+        if (!isDropAllowed(dragSrc.lane, key)) {
           // Visually flag the rejection but don't preventDefault — the drop
-          // will be ignored by the browser since we never accept it.
-          container.classList.add('drag-over');
+          // will be ignored by the browser since we never accept it. Covers
+          // the closedVisible → auto no-op case (issue #38). Surface a
+          // plain-language reason in the footer (issue #41).
+          container.classList.add('drag-over', 'drop-rejected');
+          const reason = rejectionReason(dragSrc.lane, key);
+          if (reason) {
+            setStatus(reason, false);
+            rejectionShown = true;
+          }
           return;
         }
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
         container.classList.add('drag-over');
+        container.classList.remove('drop-rejected');
       });
       container.addEventListener('dragleave', (e) => {
         // Only clear when leaving the container (not when crossing into a
         // child card). relatedTarget is the element we're entering.
         if (e.relatedTarget && container.contains(e.relatedTarget)) return;
-        container.classList.remove('drag-over');
+        container.classList.remove('drag-over', 'drop-rejected');
+        // Clear the rejection status when the cursor leaves the rejected
+        // lane — keeps the footer accurate as the user keeps dragging.
+        if (rejectionShown && !isDropAllowed(dragSrc?.lane, key)) {
+          setStatus('', false);
+          rejectionShown = false;
+        }
       });
       container.addEventListener('drop', (e) => {
         if (!dragSrc) return;
         container.classList.remove('drag-over');
-        if (!DROPPABLE[key]) return;
+        if (!isDropAllowed(dragSrc.lane, key)) return;
         // If a child card already handled this drop, bail — its handler
         // calls stopPropagation(). This branch covers empty-lane drops and
         // drops past the last card in a lane.
@@ -202,13 +247,33 @@
   // Apply a move to the local state, then ship the full layout to the host.
   function moveCard(name, srcLane, dstLane, position) {
     if (!srcLane || !dstLane) return;
-    if (!DROPPABLE[dstLane]) return;
+    if (!isDropAllowed(srcLane, dstLane)) return;
     if (srcLane === dstLane && position && position.relative === name) return;
 
-    // Remove from source lane.
+    // Find the card up-front so the live-tile-into-closedVisible branch can
+    // route on its `isLive` flag without touching local lane state.
     const srcArr = state[srcLane];
     const idx = srcArr.findIndex((c) => c.name === name);
     if (idx === -1) return;
+    const sourceCard = srcArr[idx];
+
+    // Live tile → closedVisible means "close the terminal" — runtime action,
+    // not a config edit. Let the extension show the confirmation modal and
+    // dispose the terminal; the next state push will reflect the result
+    // naturally. No local lane mutation here — if the user cancels, nothing
+    // should change in the panel. (Non-live tiles fall through to the
+    // standard config-only path: clearing pinned/hidden lands them in
+    // closedVisible via runtime derivation in postState.)
+    if (dstLane === 'closedVisible' && sourceCard.isLive) {
+      vscode.postMessage({
+        type: 'organizer:closeTerminal',
+        name: sourceCard.name,
+        displayName: sourceCard.displayName,
+      });
+      return;
+    }
+
+    // Remove from source lane.
     const [card] = srcArr.splice(idx, 1);
 
     // Apply card stamp changes for cross-lane moves so the immediate render

--- a/media/webview.css
+++ b/media/webview.css
@@ -174,6 +174,16 @@ body {
   animation: ready-pulse 2s ease-in-out infinite;
 }
 
+/* v0.19 (#36) — burst pulse for ~3s after a ready transition. Faster
+   animation + glow so the just-finished tile is visually unmissable
+   while the audio chime fires in parallel. Class auto-clears via a
+   tracker-side timer. Doubled selector specificity wins over `.dot.ready`
+   regardless of declaration order. */
+.dot.ready.fresh {
+  animation: ready-pulse-fresh 0.6s ease-in-out 5;
+  box-shadow: 0 0 6px 2px var(--vscode-terminal-ansiCyan);
+}
+
 .dot.waiting {
   background: var(--vscode-terminal-ansiYellow);
   animation: blink 1s step-end infinite;
@@ -245,6 +255,14 @@ body {
 @keyframes ready-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }
+}
+
+/* v0.19 (#36) — sharper, brighter pulse for the 3s burst window after a
+   ready transition. Pairs scale + opacity for a noticeable "thump" that
+   peripheral vision picks up. */
+@keyframes ready-pulse-fresh {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(1.4); }
 }
 
 @keyframes blink {

--- a/media/webview.js
+++ b/media/webview.js
@@ -222,7 +222,11 @@ function patchTile(el, tile) {
       : (tile.status === 'registered' && tile.type === 'shell')
         ? 'shell'
         : tile.status;
-    dot.className = `dot ${dotClass}`;
+    // v0.19 (#36) — `fresh` decorates the cyan ready pulse for ~3s after
+    // a transition into ready so the just-finished tile is visually
+    // unmissable. Tracker clears the flag via a per-tile timer.
+    const fresh = tile.status === 'ready' && tile.freshlyReady ? ' fresh' : '';
+    dot.className = `dot ${dotClass}${fresh}`;
   }
 
   // Time
@@ -313,6 +317,8 @@ function createTileEl(tile, index) {
     : (tile.status === 'registered' && tile.type === 'shell')
       ? 'shell'
       : tile.status;
+  // v0.19 (#36) — fresh-ready burst class on initial render too.
+  const fresh = tile.status === 'ready' && tile.freshlyReady ? ' fresh' : '';
 
   const iconHtml = tile.icon
     ? `<span class="tile-icon codicon codicon-${escapeHtml(tile.icon)}"></span>`
@@ -326,7 +332,7 @@ function createTileEl(tile, index) {
 
   el.innerHTML = `
     <div class="tile-header">
-      <span class="dot ${dotClass}"></span>
+      <span class="dot ${dotClass}${fresh}"></span>
       ${iconHtml}
       <span class="tile-name">${escapeHtml(displayName)}</span>
       ${tile.status !== 'idle' ? `<span class="tile-time">${timeStr}</span>` : '<span class="tile-time"></span>'}
@@ -548,6 +554,20 @@ function showContextMenu(e, tileId) {
     vscode.postMessage({ type: 'setPinned', id: tileId, pinned: !isPinned });
   });
   menu.appendChild(pinItem);
+
+  // v0.19 (#34) — Copy a keybindings.json snippet for this tile so users
+  // can wire a focus hotkey without remembering the focusByName syntax.
+  // VS Code has no first-class API for dynamically registering keybindings
+  // from an extension, so the snippet-to-clipboard route is the path that
+  // works today. Skip on registered/synthetic tiles — they don't have a
+  // live VS Code terminal to focus, and their slug is the only reachable
+  // identity (no nickname-as-projectName until launched).
+  if (!isRegistered) {
+    const hotkeyItem = menuItem('⌨', 'Copy hotkey JSON…', () => {
+      vscode.postMessage({ type: 'copyHotkeyJson', id: tileId });
+    });
+    menu.appendChild(hotkeyItem);
+  }
 
   // v0.12 — Mute / Unmute audio + Launch another project. Both are
   // Claude-workflow items — skip them on shell tiles.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claudelike-bar",
   "displayName": "Claudelike Bar",
   "description": "Live sidebar for Claude Code terminals — see what every session is doing at a glance without tab-switching.",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "publisher": "harteWired",
   "icon": "media/icon.png",
   "repository": {
@@ -113,6 +113,11 @@
         "command": "claudeDashboard.organizeProjects",
         "title": "Organize Projects",
         "icon": "$(layout)",
+        "category": "Claudelike Bar"
+      },
+      {
+        "command": "claudeDashboard.broadcast",
+        "title": "Broadcast to All Tracked Terminals",
         "category": "Claudelike Bar"
       },
       {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claudelike-bar",
   "displayName": "Claudelike Bar",
   "description": "Live sidebar for Claude Code terminals — see what every session is doing at a glance without tab-switching.",
-  "version": "0.18.2",
+  "version": "0.19.0-pre",
   "publisher": "harteWired",
   "icon": "media/icon.png",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -191,6 +191,53 @@
         "category": "Claudelike Bar"
       }
     ],
+    "keybindings": [
+      {
+        "command": "claudeDashboard.focusSlot1",
+        "key": "ctrl+alt+1",
+        "mac": "cmd+alt+1"
+      },
+      {
+        "command": "claudeDashboard.focusSlot2",
+        "key": "ctrl+alt+2",
+        "mac": "cmd+alt+2"
+      },
+      {
+        "command": "claudeDashboard.focusSlot3",
+        "key": "ctrl+alt+3",
+        "mac": "cmd+alt+3"
+      },
+      {
+        "command": "claudeDashboard.focusSlot4",
+        "key": "ctrl+alt+4",
+        "mac": "cmd+alt+4"
+      },
+      {
+        "command": "claudeDashboard.focusSlot5",
+        "key": "ctrl+alt+5",
+        "mac": "cmd+alt+5"
+      },
+      {
+        "command": "claudeDashboard.focusSlot6",
+        "key": "ctrl+alt+6",
+        "mac": "cmd+alt+6"
+      },
+      {
+        "command": "claudeDashboard.focusSlot7",
+        "key": "ctrl+alt+7",
+        "mac": "cmd+alt+7"
+      },
+      {
+        "command": "claudeDashboard.focusSlot8",
+        "key": "ctrl+alt+8",
+        "mac": "cmd+alt+8"
+      },
+      {
+        "command": "claudeDashboard.focusSlot9",
+        "key": "ctrl+alt+9",
+        "mac": "cmd+alt+9"
+      }
+    ],
     "menus": {
       "view/title": [
         {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claudelike-bar",
   "displayName": "Claudelike Bar",
   "description": "Live sidebar for Claude Code terminals — see what every session is doing at a glance without tab-switching.",
-  "version": "0.19.0-pre",
+  "version": "0.19.1",
   "publisher": "harteWired",
   "icon": "media/icon.png",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,12 @@
         "category": "Claudelike Bar"
       },
       {
+        "command": "claudeDashboard.organizeProjects",
+        "title": "Organize Projects",
+        "icon": "$(layout)",
+        "category": "Claudelike Bar"
+      },
+      {
         "command": "claudeDashboard.showHooks",
         "title": "Show Me the Hooks (open docs)",
         "category": "Claudelike Bar"
@@ -194,6 +200,11 @@
         },
         {
           "command": "claudeDashboard.registerProject",
+          "when": "view == claudeDashboard.mainView",
+          "group": "navigation"
+        },
+        {
+          "command": "claudeDashboard.organizeProjects",
           "when": "view == claudeDashboard.mainView",
           "group": "navigation"
         },

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -177,6 +177,11 @@ const DEFAULT_AUDIO_DEBOUNCE_MS = 150;
 const CONFIG_FILENAME = '.claudelike-bar.jsonc';
 const LEGACY_CONFIG_FILENAME = '.claudelike-bar.json';
 
+// Names that resolve to live prototype objects under bracket-notation
+// lookup. Filtered at any boundary that takes terminal names from a
+// webview/IPC source so writes can't pollute Object.prototype.
+const RESERVED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 const DEFAULT_LABELS: Record<string, string> = {
   idle: 'Idle',
   working: 'Working',
@@ -684,6 +689,74 @@ export class ConfigManager implements vscode.Disposable {
       if (entry) entry.order = index;
     });
     this.config.sortMode = 'manual';
+    this.scheduleSave();
+  }
+
+  /**
+   * v0.19 — atomic layout write from the tile-organizer panel. The webview
+   * owns the full lane-membership picture; this method just applies it in a
+   * single config write.
+   *
+   *   pinnedOrder    — names with `pinned: true`, in the panel's display order
+   *                    (translates to `order: 0..N-1` within the pinned zone)
+   *   unpinnedNames  — names with `pinned: false, hidden: false`. Covers both
+   *                    "Auto-sort" (running) and "Closed but visible" lanes,
+   *                    which share config state and only differ at runtime.
+   *                    Order isn't persisted — auto-sort is status-driven.
+   *   hiddenNames    — names with `hidden: true`. Order doesn't matter;
+   *                    these tiles don't appear in the bar at all.
+   *
+   * Names not present in any list keep their existing flags (defensive — the
+   * panel is supposed to enumerate everything, but a stale message from a
+   * cached webview shouldn't silently archive tiles).
+   */
+  applyOrganizerLayout(layout: {
+    pinnedOrder: string[];
+    unpinnedNames: string[];
+    hiddenNames: string[];
+  }): void {
+    // Reject reserved property names — the webview is shipped by the
+    // extension today, but bracket-notation lookups on `__proto__` /
+    // `constructor` / `prototype` would return live prototype objects and
+    // turn any future webview message-channel slip into a host-wide
+    // prototype-pollution gadget. Belt-and-braces with hasOwnProperty.call.
+    const lookup = (name: string): TerminalConfig | undefined => {
+      if (RESERVED_KEYS.has(name)) return undefined;
+      if (!Object.prototype.hasOwnProperty.call(this.config.terminals, name)) {
+        return undefined;
+      }
+      return this.config.terminals[name];
+    };
+    // Wipe stale `order` values — pinnedOrder reassigns the only ones we
+    // care about, and unpinned/hidden tiles must not carry orders that the
+    // pinned-zone sort would treat as authoritative.
+    for (const cfg of Object.values(this.config.terminals)) {
+      delete cfg.order;
+    }
+    layout.pinnedOrder.forEach((name, i) => {
+      const e = lookup(name);
+      if (!e) return;
+      e.pinned = true;
+      delete e.hidden;
+      e.order = i;
+    });
+    for (const name of layout.unpinnedNames) {
+      const e = lookup(name);
+      if (!e) continue;
+      delete e.pinned;
+      delete e.hidden;
+    }
+    for (const name of layout.hiddenNames) {
+      const e = lookup(name);
+      if (!e) continue;
+      delete e.pinned;
+      e.hidden = true;
+    }
+    // Flip sortMode to 'auto' so the bar's unpinned-tile order matches what
+    // the panel just showed — wiping `order` on unpinned tiles while
+    // sortMode='manual' would otherwise fall back to lastActivity sort and
+    // silently undo any prior in-bar drag-reorder.
+    this.config.sortMode = 'auto';
     this.scheduleSave();
   }
 

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -185,6 +185,14 @@ export interface ConfigFile {
    * runtime action shouldn't be silently armed on first install.
    */
   confirmCloseOnDrop?: boolean;
+  /**
+   * v0.19 (#48) — set true after the user has seen and dismissed the
+   * one-time toast that fires the first time a pinned tile's terminal
+   * exits and the pin is auto-cleared. Capped at one notification per
+   * workspace, ever — once flipped to true, the toast never fires again.
+   * Default false (toast still pending).
+   */
+  seenPinClearedNotice?: boolean;
   terminals: Record<string, TerminalConfig>;
 }
 
@@ -838,6 +846,18 @@ export class ConfigManager implements vscode.Disposable {
     return this.config.showRegisteredProjects !== false;
   }
 
+  /**
+   * v0.19 — prototype-pollution-safe membership check. Plain
+   * `getTerminal('__proto__')` would return `Object.prototype`, so a
+   * webview message containing reserved keys could appear to refer to a
+   * valid entry. Use this anywhere an IPC-boundary name needs to be
+   * vetted before downstream operations (e.g. `launchRegisteredProject`).
+   */
+  hasTerminal(name: string): boolean {
+    if (RESERVED_KEYS.has(name)) return false;
+    return Object.prototype.hasOwnProperty.call(this.config.terminals, name);
+  }
+
   /** v0.19 (#41) — confirmation modal preference for drop-to-close. */
   getConfirmCloseOnDrop(): boolean {
     return this.config.confirmCloseOnDrop !== false;
@@ -846,6 +866,18 @@ export class ConfigManager implements vscode.Disposable {
   setConfirmCloseOnDrop(value: boolean): void {
     if (this.config.confirmCloseOnDrop === value) return;
     this.config.confirmCloseOnDrop = value;
+    this.scheduleSave();
+  }
+
+  /** v0.19 (#48) — true once the first-auto-unpin toast has been dismissed. */
+  getSeenPinClearedNotice(): boolean {
+    return this.config.seenPinClearedNotice === true;
+  }
+
+  setSeenPinClearedNotice(value: boolean): void {
+    if (this.config.seenPinClearedNotice === value) return;
+    if (value) this.config.seenPinClearedNotice = true;
+    else delete this.config.seenPinClearedNotice;
     this.scheduleSave();
   }
 
@@ -921,6 +953,9 @@ export class ConfigManager implements vscode.Disposable {
     // Emit confirmCloseOnDrop only when the user has explicitly opted out
     // of the modal (clicked "Don't ask again"). Default true → absent.
     const confirmCloseOnDropOverride = this.config.confirmCloseOnDrop === false;
+    // Emit seenPinClearedNotice only when the user has dismissed the toast
+    // (clicked "Don't show again"). Default false → absent.
+    const seenPinClearedNoticeOverride = this.config.seenPinClearedNotice === true;
     const labels = { ...DEFAULT_LABELS, ...this.config.labels };
     const thresholds = this.getContextThresholds();
     const ignoredTexts = this.getIgnoredTexts();
@@ -1011,6 +1046,12 @@ export class ConfigManager implements vscode.Disposable {
         '  // its terminal. You opted out of the confirmation modal — set this',
         '  // back to true (or delete the line) to re-enable the prompt.',
         '  "confirmCloseOnDrop": false,',
+        '',
+      ] : []),
+      ...(seenPinClearedNoticeOverride ? [
+        '  // The one-time toast about pin-clearing-on-terminal-exit was',
+        '  // dismissed. Delete this line (or set to false) to see it again.',
+        '  "seenPinClearedNotice": true,',
         '',
       ] : []),
       '  // \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510',

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -75,6 +75,16 @@ export interface TerminalConfig {
    * the bar alongside Claude tiles.
    */
   type?: 'claude' | 'shell';
+  /**
+   * v0.19 (#34) — preferred focus hotkey, in VS Code accelerator syntax
+   * (e.g. "ctrl+alt+a", "shift+f7"). Memo only — the extension does NOT
+   * register this binding directly because VS Code has no first-class API
+   * for dynamic keybinding registration. The "Copy hotkey JSON…" right-
+   * click action uses this value as the suggested key when generating a
+   * keybindings.json snippet for the user to paste. Set via that action
+   * or by hand-editing the config.
+   */
+  hotkey?: string | null;
 }
 
 /**
@@ -641,6 +651,22 @@ export class ConfigManager implements vscode.Disposable {
     if (pinned) entry.pinned = true;
     else delete entry.pinned;
     this.scheduleSave();
+  }
+
+  /**
+   * v0.19 (#34) — record the user's preferred focus hotkey on a tile.
+   * Memo only; VS Code can't dynamically register this. The webview's
+   * "Copy hotkey JSON…" action calls this so the chosen key persists
+   * across sessions for any future copy/paste/audit. Empty / null
+   * clears the field.
+   */
+  setHotkey(name: string, key: string | null): boolean {
+    const entry = this.config.terminals[name];
+    if (!entry) return false;
+    if (key && key.length > 0) entry.hotkey = key;
+    else delete entry.hotkey;
+    this.scheduleSave();
+    return true;
   }
 
   /**

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -177,6 +177,14 @@ export interface ConfigFile {
    * by side if both are enabled.
    */
   pushNotifications?: boolean;
+  /**
+   * v0.19 (#41) — when false, the "Close terminal?" confirmation modal
+   * shown after dragging a live tile into the "Closed but visible" lane
+   * is skipped (the terminal is closed immediately). Set by the modal's
+   * "Don't ask again" button. Defaults to true (show modal) — destructive
+   * runtime action shouldn't be silently armed on first install.
+   */
+  confirmCloseOnDrop?: boolean;
   terminals: Record<string, TerminalConfig>;
 }
 
@@ -783,6 +791,12 @@ export class ConfigManager implements vscode.Disposable {
     // sortMode='manual' would otherwise fall back to lastActivity sort and
     // silently undo any prior in-bar drag-reorder.
     this.config.sortMode = 'auto';
+    // Fire onChange synchronously so listeners (bar, organizer) re-render
+    // immediately. The FS-watcher-triggered reload that normally fires
+    // onChange after a save round-trip is suppressed by the isSaving flag
+    // (configManager.ts:378), so without this synchronous fire the bar
+    // never observes pinned/hidden flag flips from drag operations.
+    this.onChangeEmitter.fire();
     this.scheduleSave();
   }
 
@@ -822,6 +836,17 @@ export class ConfigManager implements vscode.Disposable {
 
   getShowRegisteredProjects(): boolean {
     return this.config.showRegisteredProjects !== false;
+  }
+
+  /** v0.19 (#41) — confirmation modal preference for drop-to-close. */
+  getConfirmCloseOnDrop(): boolean {
+    return this.config.confirmCloseOnDrop !== false;
+  }
+
+  setConfirmCloseOnDrop(value: boolean): void {
+    if (this.config.confirmCloseOnDrop === value) return;
+    this.config.confirmCloseOnDrop = value;
+    this.scheduleSave();
   }
 
   private scheduleSave(): void {
@@ -893,6 +918,9 @@ export class ConfigManager implements vscode.Disposable {
     const sortMode = this.getSortMode();
     const claudeCommand = this.config.claudeCommand ?? null;
     const debug = this.config.debug === true;
+    // Emit confirmCloseOnDrop only when the user has explicitly opted out
+    // of the modal (clicked "Don't ask again"). Default true → absent.
+    const confirmCloseOnDropOverride = this.config.confirmCloseOnDrop === false;
     const labels = { ...DEFAULT_LABELS, ...this.config.labels };
     const thresholds = this.getContextThresholds();
     const ignoredTexts = this.getIgnoredTexts();
@@ -978,6 +1006,13 @@ export class ConfigManager implements vscode.Disposable {
       '  // Use this to diagnose stuck tiles or missing status events.',
       `  "debug": ${JSON.stringify(debug)},`,
       '',
+      ...(confirmCloseOnDropOverride ? [
+        '  // Dragging a live tile into the "Closed but visible" lane closes',
+        '  // its terminal. You opted out of the confirmation modal — set this',
+        '  // back to true (or delete the line) to re-enable the prompt.',
+        '  "confirmCloseOnDrop": false,',
+        '',
+      ] : []),
       '  // \u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510',
       '  // \u2502  FINE TUNING                                    \u2502',
       '  // \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2518',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { DashboardProvider } from './dashboardProvider';
+import { OrganizerProvider } from './organizerProvider';
 import { TerminalTracker } from './terminalTracker';
 import { StatusWatcher } from './statusWatcher';
 import { ConfigManager } from './configManager';
@@ -89,6 +90,7 @@ export function activate(context: vscode.ExtensionContext) {
   const tracker = new TerminalTracker(configManager, log);
   const watcher = new StatusWatcher();
   const provider = new DashboardProvider(context.extensionUri);
+  const organizer = new OrganizerProvider(context.extensionUri, configManager, tracker);
 
   // Register the webview provider
   const registration = vscode.window.registerWebviewViewProvider(
@@ -130,6 +132,10 @@ export function activate(context: vscode.ExtensionContext) {
   const setupProjectsCmd = vscode.commands.registerCommand(
     'claudeDashboard.setupProjects',
     () => runSetupWizard(configManager, context.extensionPath, (m) => log(m)),
+  );
+  const organizeProjectsCmd = vscode.commands.registerCommand(
+    'claudeDashboard.organizeProjects',
+    () => organizer.show(),
   );
   const showHooksCmd = vscode.commands.registerCommand(
     'claudeDashboard.showHooks',
@@ -557,6 +563,8 @@ export function activate(context: vscode.ExtensionContext) {
     registerProjectCmd,
     launchProjectCmd,
     setupProjectsCmd,
+    organizeProjectsCmd,
+    organizer,
     showHooksCmd,
     removeLegacyHooksCmd,
     diagnoseCmd,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -478,6 +478,60 @@ export function activate(context: vscode.ExtensionContext) {
           refreshTiles();
         }
         break;
+
+      case 'copyHotkeyJson': {
+        // v0.19 (#34) — generate a keybindings.json snippet for this tile
+        // and put it on the clipboard. VS Code has no first-class dynamic
+        // keybinding API, so paste-into-keybindings.json is the path that
+        // works today. Pre-fills the InputBox with any prior `hotkey` from
+        // config so the user's choice persists across reopens.
+        const tile = tracker.getTiles().find((t) => t.id === message.id);
+        if (!tile) break;
+        const cfg = configManager.getTerminal(tile.name);
+        const focusName = cfg?.projectName ?? tile.displayName ?? tile.name;
+        const previous = (cfg?.hotkey && typeof cfg.hotkey === 'string') ? cfg.hotkey : '';
+        vscode.window.showInputBox({
+          prompt: `Hotkey for "${tile.displayName}" (e.g. ctrl+alt+a, shift+f7)`,
+          value: previous,
+          placeHolder: 'ctrl+alt+a',
+          validateInput: (raw) => {
+            const v = raw.trim();
+            if (v.length === 0) return null;
+            // Loose check — VS Code accepts pretty-much any string and
+            // surfaces its own parse errors at registration time. We only
+            // catch obvious nonsense (bare modifiers, spaces inside keys).
+            if (!/^[a-zA-Z0-9+\- ]+$/.test(v)) {
+              return 'Use VS Code accelerator syntax — modifiers + key separated by "+" (e.g. ctrl+alt+a).';
+            }
+            return null;
+          },
+        }).then((result) => {
+          if (result === undefined) return;          // user cancelled
+          const key = result.trim();
+          if (key.length === 0) {
+            configManager.setHotkey(tile.name, null);
+            vscode.window.showInformationMessage(`Cleared hotkey for "${tile.displayName}".`);
+            return;
+          }
+          configManager.setHotkey(tile.name, key);
+          const snippet = JSON.stringify({
+            command: 'claudeDashboard.focusByName',
+            args: focusName,
+            key,
+          }, null, 2);
+          void vscode.env.clipboard.writeText(snippet + ',');
+          vscode.window.showInformationMessage(
+            `Hotkey snippet copied. Open keybindings.json (Ctrl+Shift+P → "Open Keyboard Shortcuts (JSON)") and paste inside the array.`,
+            'Open keybindings.json',
+          ).then((choice) => {
+            if (choice === 'Open keybindings.json') {
+              void vscode.commands.executeCommand('workbench.action.openGlobalKeybindingsFile');
+            }
+          });
+          log(`copyHotkeyJson ${tile.name}: → "${key}"`);
+        });
+        break;
+      }
     }
   };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,7 +90,7 @@ export function activate(context: vscode.ExtensionContext) {
   const tracker = new TerminalTracker(configManager, log);
   const watcher = new StatusWatcher();
   const provider = new DashboardProvider(context.extensionUri);
-  const organizer = new OrganizerProvider(context.extensionUri, configManager, tracker);
+  const organizer = new OrganizerProvider(context.extensionUri, configManager, tracker, log);
 
   // Register the webview provider
   const registration = vscode.window.registerWebviewViewProvider(
@@ -128,6 +128,18 @@ export function activate(context: vscode.ExtensionContext) {
   const launchProjectCmd = vscode.commands.registerCommand(
     'claudeDashboard.launchProject',
     () => executeLaunchProjectCommand(configManager, tracker, (m) => log(m)),
+  );
+  // v0.19 (#44) — name-targeted launch. The organizer panel dispatches
+  // this for each tile its drop pulled from the closed lane into an
+  // active lane; the bar's existing `launchByName` webview message also
+  // routes through this command path.
+  const launchByNameCmd = vscode.commands.registerCommand(
+    'claudeDashboard.launchByName',
+    (name: unknown) => {
+      if (typeof name !== 'string') return;
+      if (!configManager.hasTerminal(name)) return;
+      launchRegisteredProject(configManager, tracker, name, (m) => log(m));
+    },
   );
   const setupProjectsCmd = vscode.commands.registerCommand(
     'claudeDashboard.setupProjects',
@@ -583,6 +595,32 @@ export function activate(context: vscode.ExtensionContext) {
     });
   });
 
+  // v0.19 (#48) — first-auto-unpin toast. Fires at most once per workspace:
+  // after the user clicks "Don't show again", `seenPinClearedNotice` flips
+  // to true in config and this listener short-circuits forever after. The
+  // toast is non-modal — VS Code parks it in the bottom-right; users who
+  // never interact still get the auto-unpin behavior without UI blocking.
+  // Lives here (not in TerminalTracker) so the state machine stays free of
+  // user-facing notification concerns — tracker just fires the event.
+  const pinClearedSub = tracker.onPinCleared(({ displayName }) => {
+    if (configManager.getSeenPinClearedNotice()) return;
+    const DONT_SHOW = "Don't show again";
+    const OPEN_CONFIG = 'Open config';
+    void Promise.resolve(
+      vscode.window.showInformationMessage(
+        `Pin removed for "${displayName}" because its terminal closed. Use autoStart to keep it pinned across restarts.`,
+        DONT_SHOW,
+        OPEN_CONFIG,
+      ),
+    ).then((choice) => {
+      if (choice === DONT_SHOW) {
+        configManager.setSeenPinClearedNotice(true);
+      } else if (choice === OPEN_CONFIG) {
+        void vscode.commands.executeCommand('claudeDashboard.openConfig');
+      }
+    });
+  });
+
   // Refresh tiles when config file changes (color/nickname/mode edits).
   // The AudioPlayer's warn-once memory is also cleared so a file the user
   // just dropped in gets a fresh chance to be picked up.
@@ -616,6 +654,7 @@ export function activate(context: vscode.ExtensionContext) {
     restoreStatuslineCmd,
     registerProjectCmd,
     launchProjectCmd,
+    launchByNameCmd,
     setupProjectsCmd,
     organizeProjectsCmd,
     organizer,
@@ -633,6 +672,7 @@ export function activate(context: vscode.ExtensionContext) {
     configSub,
     audioPlayer,
     pushSub,
+    pinClearedSub,
     output,
     timerDisposable,
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -149,6 +149,67 @@ export function activate(context: vscode.ExtensionContext) {
     'claudeDashboard.organizeProjects',
     () => organizer.show(),
   );
+  // v0.20 (#55) — fan-out send. InputBox + last-value memory in globalState
+  // (matches CLB's user-global config philosophy). Single-window only in v1:
+  // vscode.window.terminals is window-scoped, and CLB's tracker mirrors it,
+  // so cross-window fan-out would need a file-based broadcast bus (deferred
+  // — issue #55 v1.5). The per-state tally written to the output channel
+  // compensates for v1 having no filter UI: the user sees exactly which
+  // tile states were hit and can re-broadcast if something landed mid-turn.
+  const BROADCAST_LAST_KEY = 'clb.lastBroadcast';
+  const broadcastCmd = vscode.commands.registerCommand(
+    'claudeDashboard.broadcast',
+    async () => {
+      const last = context.globalState.get<string>(BROADCAST_LAST_KEY, '');
+      const text = await vscode.window.showInputBox({
+        prompt: 'Text to broadcast to every tracked terminal (newline appended)',
+        placeHolder: '/compress fast',
+        value: last,
+      });
+      if (text === undefined) return; // user dismissed
+      if (text.length === 0) return; // empty — treat as cancel, don't persist
+      await context.globalState.update(BROADCAST_LAST_KEY, text);
+
+      const tally: Record<string, number> = {};
+      const hitNames: string[] = [];
+      const failures: string[] = [];
+      tracker.forEachTrackedTerminal((term, tile) => {
+        try {
+          term.sendText(text, true);
+          tally[tile.status] = (tally[tile.status] ?? 0) + 1;
+          hitNames.push(tile.name);
+        } catch (err) {
+          failures.push(`${tile.name}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      });
+
+      const total = hitNames.length;
+      if (total === 0) {
+        vscode.window.showInformationMessage(
+          'Claudelike Bar: no tracked terminals to broadcast to.',
+        );
+        return;
+      }
+
+      // Always log — broadcast is a user-explicit action, not background noise,
+      // so the line lands even when debug mode is off. Per-state breakdown
+      // makes it easy to spot when text was queued into a `working` tile.
+      const breakdown = Object.entries(tally)
+        .sort(([, a], [, b]) => b - a)
+        .map(([s, n]) => `${n} ${s}`)
+        .join(', ');
+      output.appendLine(
+        `[${new Date().toISOString().slice(11, 19)}] broadcast ${JSON.stringify(text)} → ${total} terminal${total === 1 ? '' : 's'} (${breakdown}) — [${hitNames.join(', ')}]`,
+      );
+      if (failures.length > 0) {
+        output.appendLine(`  failures: ${failures.join('; ')}`);
+      }
+
+      vscode.window.showInformationMessage(
+        `Broadcast sent to ${total} terminal${total === 1 ? '' : 's'} in this window (${breakdown}).`,
+      );
+    },
+  );
   const showHooksCmd = vscode.commands.registerCommand(
     'claudeDashboard.showHooks',
     () => vscode.env.openExternal(vscode.Uri.parse(HOOKS_DOC_URL)),
@@ -658,6 +719,7 @@ export function activate(context: vscode.ExtensionContext) {
     setupProjectsCmd,
     organizeProjectsCmd,
     organizer,
+    broadcastCmd,
     showHooksCmd,
     removeLegacyHooksCmd,
     diagnoseCmd,

--- a/src/launchProject.ts
+++ b/src/launchProject.ts
@@ -62,6 +62,15 @@ export function launchRegisteredProject(
     ...(opts.shellArgs ? { shellArgs: opts.shellArgs } : {}),
   });
 
+  // v0.19 (#45) — attach the terminal to the tracker synchronously so the
+  // tile transitions from "registered" → "idle" the instant the launch
+  // resolves, not after VS Code's async onDidOpenTerminal event fires. The
+  // event listener still runs but is idempotent (assignId reuses the id
+  // via WeakMap), so no double-tile. This closes the "offline ghost"
+  // window the user observed when the bar still rendered the registered
+  // (greyed) tile after a drag-launched terminal had already been created.
+  tracker.attachLaunchedTerminal(terminal);
+
   const command = configManager.getAutoStartCommand(name);
   if (command) {
     log(() => `launch: ${name} → ${command}${opts.cwd ? ` [cwd: ${opts.cwd}]` : ''}${opts.shellPath ? ` [shell: ${opts.shellPath}]` : ''}`);

--- a/src/organizerProvider.ts
+++ b/src/organizerProvider.ts
@@ -3,6 +3,8 @@ import { ConfigManager } from './configManager';
 import { TerminalTracker } from './terminalTracker';
 import { getThemeColor } from './types';
 
+type LogFn = (msg: string | (() => string)) => void;
+
 /**
  * v0.19 — tile-organizer panel. Editor-area webview (not sidebar) that
  * renders four lanes of cards for managing tile visibility and pinning:
@@ -38,10 +40,18 @@ export class OrganizerProvider implements vscode.Disposable {
   private suppressOwnEcho = false;
   private suppressOwnEchoTimer: ReturnType<typeof setTimeout> | undefined;
 
-  constructor(extensionUri: vscode.Uri, configManager: ConfigManager, tracker: TerminalTracker) {
+  private log: LogFn;
+
+  constructor(
+    extensionUri: vscode.Uri,
+    configManager: ConfigManager,
+    tracker: TerminalTracker,
+    log?: LogFn,
+  ) {
     this.extensionUri = extensionUri;
     this.configManager = configManager;
     this.tracker = tracker;
+    this.log = log ?? (() => {});
   }
 
   show(): void {
@@ -80,7 +90,13 @@ export class OrganizerProvider implements vscode.Disposable {
     this.postState();
   }
 
-  private handleMessage(msg: unknown): void {
+  /**
+   * Handle a webview message. Public so unit tests can drive the message
+   * flow without standing up the real WebviewPanel — VS Code's panel API
+   * isn't mockable in the test harness. Production code wires this up via
+   * `onDidReceiveMessage` in `show()`.
+   */
+  handleMessage(msg: unknown): void {
     if (!msg || typeof msg !== 'object') return;
     const m = msg as { type?: unknown };
     if (typeof m.type !== 'string') return;
@@ -89,6 +105,7 @@ export class OrganizerProvider implements vscode.Disposable {
         pinnedOrder?: unknown;
         unpinnedNames?: unknown;
         hiddenNames?: unknown;
+        launchNames?: unknown;
       };
       const asNameList = (v: unknown): string[] =>
         Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
@@ -107,6 +124,34 @@ export class OrganizerProvider implements vscode.Disposable {
         unpinnedNames: asNameList(layout.unpinnedNames),
         hiddenNames: asNameList(layout.hiddenNames),
       });
+      // v0.19 (#44) — names that arrived with the drop because the
+      // destination lane (Pinned or Auto-sort) requires a live terminal.
+      // Dispatched via the registered `claudeDashboard.launchByName`
+      // command rather than calling the launch helper directly — keeps
+      // the launch path centralized so future permission checks, telemetry,
+      // or pre-launch hooks added there cover organizer drops too. The
+      // command handler attaches the terminal synchronously via
+      // tracker.attachLaunchedTerminal so the tile renders as idle
+      // (not offline) the instant it resolves — closes the offline-ghost
+      // window the user reported in #45.
+      //
+      // The command handler already filters via configManager.hasTerminal
+      // (defense-in-depth against a compromised webview producing names
+      // not in config), but we filter here too so the log message is
+      // attributable to organizer-side input. Reserved keys
+      // (`__proto__` / `constructor` / `prototype`) are rejected via the
+      // same hasTerminal call.
+      const launchNames = asNameList(layout.launchNames)
+        .filter((name) => {
+          if (!this.configManager.hasTerminal(name)) {
+            this.log(() => `organizer: dropped unknown name "${name}" — skipped`);
+            return false;
+          }
+          return true;
+        });
+      for (const name of launchNames) {
+        void vscode.commands.executeCommand('claudeDashboard.launchByName', name);
+      }
       // Eager echo: webview gets the new state immediately rather than
       // waiting for the debounced save → onChange round-trip.
       this.postState();

--- a/src/organizerProvider.ts
+++ b/src/organizerProvider.ts
@@ -1,0 +1,255 @@
+import * as vscode from 'vscode';
+import { ConfigManager } from './configManager';
+import { TerminalTracker } from './terminalTracker';
+import { getThemeColor } from './types';
+
+/**
+ * v0.19 — tile-organizer panel. Editor-area webview (not sidebar) that
+ * renders four lanes of cards for managing tile visibility and pinning:
+ *
+ *   1. Auto-sort      — running, status-driven order in the bar
+ *   2. Pinned         — fixed-position zone at the bar bottom
+ *   3. Closed visible — registered, terminal not running (passive lane,
+ *                       drop-disabled — tiles auto-appear here)
+ *   4. Hidden         — `hidden: true`, not in the bar at all
+ *
+ * Lanes 1 and 3 share the same `(pinned: false, hidden: false)` config
+ * state — the difference is runtime liveness, derived from TerminalTracker.
+ *
+ * Drag/drop semantics:
+ *   - Drag → Pinned: sets `pinned: true`, position assigns `order`
+ *   - Drag → Auto-sort: sets `pinned: false, hidden: false`, no order
+ *   - Drag → Hidden: sets `hidden: true`
+ *   - Drag → Closed visible: rejected at the webview (passive lane)
+ *
+ * The webview owns the lane layout and ships the full picture back via a
+ * single `applyLayout` message; ConfigManager applies it atomically.
+ */
+export class OrganizerProvider implements vscode.Disposable {
+  private panel: vscode.WebviewPanel | undefined;
+  private extensionUri: vscode.Uri;
+  private configManager: ConfigManager;
+  private tracker: TerminalTracker;
+  private subDisposables: vscode.Disposable[] = [];
+  // Set briefly after our own `applyOrganizerLayout` write so the
+  // configManager.onChange listener (which fires once the debounced disk
+  // write completes) doesn't double-post the same state we just echoed.
+  // External edits — file changed by hand — still trigger a normal sync.
+  private suppressOwnEcho = false;
+  private suppressOwnEchoTimer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(extensionUri: vscode.Uri, configManager: ConfigManager, tracker: TerminalTracker) {
+    this.extensionUri = extensionUri;
+    this.configManager = configManager;
+    this.tracker = tracker;
+  }
+
+  show(): void {
+    if (this.panel) {
+      this.panel.reveal(vscode.ViewColumn.Active);
+      return;
+    }
+    this.panel = vscode.window.createWebviewPanel(
+      'claudelikeBar.organizer',
+      'Organize Claudelike Tiles',
+      vscode.ViewColumn.Active,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'media')],
+      },
+    );
+    this.panel.iconPath = vscode.Uri.joinPath(this.extensionUri, 'media', 'dashboard.svg');
+    this.panel.webview.html = this.getHtml(this.panel.webview);
+
+    this.panel.onDidDispose(() => {
+      this.panel = undefined;
+      for (const d of this.subDisposables) d.dispose();
+      this.subDisposables = [];
+    });
+
+    this.subDisposables.push(
+      this.panel.webview.onDidReceiveMessage((msg: unknown) => this.handleMessage(msg)),
+      this.configManager.onChange(() => {
+        if (this.suppressOwnEcho) return;
+        this.postState();
+      }),
+      this.tracker.onChange(() => this.postState()),
+    );
+
+    this.postState();
+  }
+
+  private handleMessage(msg: unknown): void {
+    if (!msg || typeof msg !== 'object') return;
+    const m = msg as { type?: unknown };
+    if (typeof m.type !== 'string') return;
+    if (m.type === 'organizer:applyLayout') {
+      const layout = msg as {
+        pinnedOrder?: unknown;
+        unpinnedNames?: unknown;
+        hiddenNames?: unknown;
+      };
+      const asNameList = (v: unknown): string[] =>
+        Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+      // Suppress the configManager.onChange-triggered postState that fires
+      // ~200ms later (after the debounced save completes) — its payload is
+      // identical to the echo below, and re-posting it would redundantly
+      // rebuild the webview DOM. 300ms covers the 200ms scheduleSave debounce
+      // plus a margin for filesystem-watcher latency.
+      this.suppressOwnEcho = true;
+      if (this.suppressOwnEchoTimer) clearTimeout(this.suppressOwnEchoTimer);
+      this.suppressOwnEchoTimer = setTimeout(() => {
+        this.suppressOwnEcho = false;
+      }, 300);
+      this.configManager.applyOrganizerLayout({
+        pinnedOrder: asNameList(layout.pinnedOrder),
+        unpinnedNames: asNameList(layout.unpinnedNames),
+        hiddenNames: asNameList(layout.hiddenNames),
+      });
+      // Eager echo: webview gets the new state immediately rather than
+      // waiting for the debounced save → onChange round-trip.
+      this.postState();
+    } else if (m.type === 'organizer:requestState') {
+      this.postState();
+    } else if (m.type === 'organizer:launchProject') {
+      void vscode.commands.executeCommand('claudeDashboard.launchProject');
+    } else if (m.type === 'organizer:openConfig') {
+      void vscode.commands.executeCommand('claudeDashboard.openConfig');
+    }
+  }
+
+  private postState(): void {
+    if (!this.panel) return;
+    const all = this.configManager.getAll();
+    const liveNames = new Set(
+      this.tracker.getTiles()
+        .filter((t) => t.status !== 'registered')
+        .map((t) => t.name),
+    );
+    type Card = {
+      name: string;
+      displayName: string;
+      themeColor: string;
+      icon: string | null;
+      isShell: boolean;
+    };
+    const pinned: Array<Card & { order: number }> = [];
+    const auto: Card[] = [];
+    const closedVisible: Card[] = [];
+    const hidden: Card[] = [];
+
+    for (const [name, cfg] of Object.entries(all)) {
+      const card: Card = {
+        name,
+        displayName: cfg.nickname ?? name,
+        themeColor: getThemeColor(name, typeof cfg.color === 'string' ? cfg.color : undefined),
+        icon: cfg.icon ?? null,
+        isShell: cfg.type === 'shell',
+      };
+      if (cfg.hidden) {
+        hidden.push(card);
+      } else if (cfg.pinned) {
+        pinned.push({
+          ...card,
+          order: typeof cfg.order === 'number' ? cfg.order : Number.MAX_SAFE_INTEGER,
+        });
+      } else if (liveNames.has(name)) {
+        auto.push(card);
+      } else {
+        closedVisible.push(card);
+      }
+    }
+
+    pinned.sort((a, b) => a.order - b.order);
+    const cmp = (a: Card, b: Card) => a.displayName.localeCompare(b.displayName);
+    auto.sort(cmp);
+    closedVisible.sort(cmp);
+    hidden.sort(cmp);
+
+    void this.panel.webview.postMessage({
+      type: 'organizer:state',
+      lanes: {
+        pinned: pinned.map(({ order: _o, ...c }) => c),
+        auto,
+        closedVisible,
+        hidden,
+      },
+    });
+  }
+
+  private getHtml(webview: vscode.Webview): string {
+    const cssUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'organizer.css'));
+    const jsUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'organizer.js'));
+    const codiconCssUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'codicon.css'));
+    const codiconFontUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'codicon.ttf'));
+    const nonce = getNonce();
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; style-src ${webview.cspSource} 'nonce-${nonce}'; font-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style nonce="${nonce}">
+    @font-face {
+      font-family: "codicon";
+      font-display: block;
+      src: url("${codiconFontUri}") format("truetype");
+    }
+  </style>
+  <link href="${codiconCssUri}" rel="stylesheet">
+  <link href="${cssUri}" rel="stylesheet">
+</head>
+<body>
+  <header class="organizer-header">
+    <h1>Organize Claudelike Tiles</h1>
+    <p class="hint">Drag cards between lanes to pin, hide, or unhide tiles. Closed but visible is passive — cards land there automatically when their terminal exits.</p>
+  </header>
+  <main class="lanes">
+    <section class="lane" data-lane="pinned">
+      <header><span class="lane-title">Pinned</span><span class="lane-sub">Fixed at bar bottom — drag to reorder</span></header>
+      <div class="cards" data-droppable="true"></div>
+    </section>
+    <section class="lane" data-lane="auto">
+      <header><span class="lane-title">Auto-sort</span><span class="lane-sub">Running tiles, status-driven order</span></header>
+      <div class="cards" data-droppable="true"></div>
+    </section>
+    <section class="lane" data-lane="closedVisible">
+      <header><span class="lane-title">Closed but visible</span><span class="lane-sub">Click in the bar to launch — tiles land here when their terminal exits</span></header>
+      <div class="cards" data-droppable="false"></div>
+    </section>
+    <section class="lane" data-lane="hidden">
+      <header><span class="lane-title">Hidden</span><span class="lane-sub">Not shown in the bar — reachable via Launch Project</span></header>
+      <div class="cards" data-droppable="true"></div>
+    </section>
+  </main>
+  <footer class="organizer-footer">
+    <button type="button" data-action="openConfig">Edit config file…</button>
+    <span class="status" id="status"></span>
+  </footer>
+  <script nonce="${nonce}" src="${jsUri}"></script>
+</body>
+</html>`;
+  }
+
+  dispose(): void {
+    if (this.suppressOwnEchoTimer) {
+      clearTimeout(this.suppressOwnEchoTimer);
+      this.suppressOwnEchoTimer = undefined;
+    }
+    for (const d of this.subDisposables) d.dispose();
+    this.subDisposables = [];
+    this.panel?.dispose();
+  }
+}
+
+function getNonce(): string {
+  let text = '';
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for (let i = 0; i < 32; i++) {
+    text += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return text;
+}

--- a/src/organizerProvider.ts
+++ b/src/organizerProvider.ts
@@ -116,7 +116,45 @@ export class OrganizerProvider implements vscode.Disposable {
       void vscode.commands.executeCommand('claudeDashboard.launchProject');
     } else if (m.type === 'organizer:openConfig') {
       void vscode.commands.executeCommand('claudeDashboard.openConfig');
+    } else if (m.type === 'organizer:closeTerminal') {
+      const payload = msg as { name?: unknown; displayName?: unknown };
+      const name = typeof payload.name === 'string' ? payload.name : undefined;
+      const displayName = typeof payload.displayName === 'string'
+        ? payload.displayName
+        : name;
+      if (name) void this.handleCloseTerminal(name, displayName ?? name);
     }
+  }
+
+  /**
+   * v0.19 (#41) — drop-to-close handler. If the user hasn't opted out of
+   * the confirmation modal, show it with three buttons (Close / Cancel /
+   * Close — don't ask again). On confirm, dispose the live VS Code
+   * terminal; the tile naturally falls back into the "Closed but visible"
+   * lane via the runtime-derivation in postState(). All branches are
+   * idempotent — if the terminal is already gone (race with another close
+   * path), we silently no-op.
+   */
+  private async handleCloseTerminal(name: string, displayName: string): Promise<void> {
+    if (!this.configManager.getConfirmCloseOnDrop()) {
+      this.tracker.closeTerminalByName(name);
+      return;
+    }
+    const CLOSE = 'Close terminal';
+    const CLOSE_DONT_ASK = 'Close, don\'t ask again';
+    const choice = await vscode.window.showWarningMessage(
+      `Close the terminal for "${displayName}"? The tile will remain in the bar as a launcher.`,
+      { modal: true },
+      CLOSE,
+      CLOSE_DONT_ASK,
+    );
+    if (choice === CLOSE_DONT_ASK) {
+      this.configManager.setConfirmCloseOnDrop(false);
+      this.tracker.closeTerminalByName(name);
+    } else if (choice === CLOSE) {
+      this.tracker.closeTerminalByName(name);
+    }
+    // Any other choice (undefined / cancel / Esc) — no-op.
   }
 
   private postState(): void {
@@ -133,6 +171,7 @@ export class OrganizerProvider implements vscode.Disposable {
       themeColor: string;
       icon: string | null;
       isShell: boolean;
+      isLive: boolean;
     };
     const pinned: Array<Card & { order: number }> = [];
     const auto: Card[] = [];
@@ -146,6 +185,7 @@ export class OrganizerProvider implements vscode.Disposable {
         themeColor: getThemeColor(name, typeof cfg.color === 'string' ? cfg.color : undefined),
         icon: cfg.icon ?? null,
         isShell: cfg.type === 'shell',
+        isLive: liveNames.has(name),
       };
       if (cfg.hidden) {
         hidden.push(card);
@@ -205,7 +245,7 @@ export class OrganizerProvider implements vscode.Disposable {
 <body>
   <header class="organizer-header">
     <h1>Organize Claudelike Tiles</h1>
-    <p class="hint">Drag cards between lanes to pin, hide, or unhide tiles. Closed but visible is passive — cards land there automatically when their terminal exits.</p>
+    <p class="hint">Drag cards between lanes to pin, hide, or unhide tiles. Drop a running tile into "Closed but visible" to close its terminal (with confirmation).</p>
   </header>
   <main class="lanes">
     <section class="lane" data-lane="pinned">
@@ -217,8 +257,8 @@ export class OrganizerProvider implements vscode.Disposable {
       <div class="cards" data-droppable="true"></div>
     </section>
     <section class="lane" data-lane="closedVisible">
-      <header><span class="lane-title">Closed but visible</span><span class="lane-sub">Click in the bar to launch — tiles land here when their terminal exits</span></header>
-      <div class="cards" data-droppable="false"></div>
+      <header><span class="lane-title">Closed but visible</span><span class="lane-sub">Click in the bar to launch — drop a running tile here to close it</span></header>
+      <div class="cards" data-droppable="true"></div>
     </section>
     <section class="lane" data-lane="hidden">
       <header><span class="lane-title">Hidden</span><span class="lane-sub">Not shown in the bar — reachable via Launch Project</span></header>

--- a/src/terminalTracker.ts
+++ b/src/terminalTracker.ts
@@ -1392,6 +1392,25 @@ export class TerminalTracker implements vscode.Disposable {
     return undefined;
   }
 
+  // v0.20 (#55) — iterate live, user-visible terminals. Skips hidden tiles
+  // (the issue's stated opt-out gesture: "mark it hidden or close it first")
+  // and dead terminals (exitStatus set). Synthesized registered tiles have
+  // no terminalRefs entry so they're skipped automatically. The cb gets the
+  // live vscode.Terminal plus the tile state — callers that want to tally
+  // by status (e.g. broadcast) can branch on tile.status without a second
+  // lookup.
+  forEachTrackedTerminal(
+    cb: (terminal: vscode.Terminal, tile: TileData) => void,
+  ): void {
+    for (const [id, tile] of this.terminals) {
+      if (this.configManager.getTerminal(tile.name)?.hidden === true) continue;
+      const term = this.terminalRefs.get(id);
+      if (!term) continue;
+      if (term.exitStatus !== undefined) continue;
+      cb(term, tile);
+    }
+  }
+
   dispose(): void {
     this.stopNameRefresh();
     for (const timer of this.readyTimers.values()) {

--- a/src/terminalTracker.ts
+++ b/src/terminalTracker.ts
@@ -1085,6 +1085,25 @@ export class TerminalTracker implements vscode.Disposable {
   }
 
   /**
+   * v0.19 (#41) — close the live VS Code terminal for a tile by name.
+   * Used by the organizer panel's drop-to-close path. Returns true when a
+   * live terminal was found and disposed. The tracker's existing
+   * `onDidCloseTerminal` listener will remove the tile from
+   * `this.terminals` and fire `onChange` as part of normal cleanup, so
+   * the bar refreshes without any extra plumbing here.
+   */
+  closeTerminalByName(name: string): boolean {
+    for (const [id, tile] of this.terminals) {
+      if (tile.name !== name) continue;
+      const term = this.terminalRefs.get(id);
+      if (!term) return false;
+      term.dispose();
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * v0.16.4 (#19) — capture the last user prompt for a tile. Independent
    * of the state machine — no transitions, no label changes, just a
    * persistent string + timestamp on the tile that the webview can
@@ -1123,12 +1142,14 @@ export class TerminalTracker implements vscode.Disposable {
     // clearing logic don't need to change. Cloning the TileData here means
     // the override is render-only — the tracker's live tile state stays
     // authoritative for the state machine.
-    const all = Array.from(this.terminals.values()).map((t) => {
-      if (t.status === 'working' && t.subagentPermissionPending) {
-        return { ...t, status: 'ready' as SessionStatus };
-      }
-      return t;
-    });
+    const all = Array.from(this.terminals.values())
+      .filter((t) => this.configManager.getTerminal(t.name)?.hidden !== true)
+      .map((t) => {
+        if (t.status === 'working' && t.subagentPermissionPending) {
+          return { ...t, status: 'ready' as SessionStatus };
+        }
+        return t;
+      });
     const unpinned = all.filter((t) => !t.pinned);
     const pinned = all.filter((t) => t.pinned);
 

--- a/src/terminalTracker.ts
+++ b/src/terminalTracker.ts
@@ -52,6 +52,16 @@ export class TerminalTracker implements vscode.Disposable {
   // and doesn't carry transition detail.
   private onStateChangeEmitter = new vscode.EventEmitter<StateTransition>();
   readonly onStateChange = this.onStateChangeEmitter.event;
+
+  // v0.19 (#48) — fires when a pinned tile's terminal closes and the pin
+  // is auto-cleared. Consumed by the UI layer (extension.ts) to show the
+  // first-auto-unpin toast; this keeps user-facing notification concerns
+  // out of the state machine.
+  private onPinClearedEmitter = new vscode.EventEmitter<{
+    name: string;
+    displayName: string;
+  }>();
+  readonly onPinCleared = this.onPinClearedEmitter.event;
   private nameRefreshTimer: ReturnType<typeof setInterval> | undefined;
   private nameRefreshIdleCycles = 0;
   private configManager: ConfigManager;
@@ -103,16 +113,14 @@ export class TerminalTracker implements vscode.Disposable {
         this.startNameRefresh(); // restart polling on new terminal
         this.onChangeEmitter.fire();
       }),
-      vscode.window.onDidCloseTerminal((t) => {
-        this.removeTerminal(t);
-        this.onChangeEmitter.fire();
-      }),
+      vscode.window.onDidCloseTerminal((t) => this.handleTerminalClosed(t)),
       vscode.window.onDidChangeActiveTerminal((active) => {
         this.handleActiveTerminalChange(active);
         this.onChangeEmitter.fire();
       }),
       this.onChangeEmitter,
       this.onStateChangeEmitter,
+      this.onPinClearedEmitter,
     );
 
     // Periodically refresh terminal names — catches late profile name assignment
@@ -122,6 +130,16 @@ export class TerminalTracker implements vscode.Disposable {
   private addTerminal(terminal: vscode.Terminal): void {
     const name = terminal.name;
     if (name === 'bash' || name === 'zsh' || name === 'sh') return;
+
+    // v0.19 (#45) — idempotent. attachLaunchedTerminal() pre-attaches the
+    // terminal so the tile exists before VS Code's onDidOpenTerminal event
+    // fires. When the event then arrives, the second addTerminal call here
+    // would otherwise overwrite the tile's state machine with a fresh
+    // 'idle' entry. Bail early if the terminal is already tracked.
+    const existingId = this.terminalIdMap.get(terminal);
+    if (existingId !== undefined && this.terminals.has(existingId)) {
+      return;
+    }
 
     // v0.15.0 (#17) — VS Code "Clone terminal" produces `<parent> (copy)`
     // names. Don't write these to config: they're transient, and persisting
@@ -1081,6 +1099,57 @@ export class TerminalTracker implements vscode.Disposable {
     if (!tile) return;
     this.configManager.setPinned(tile.name, pinned);
     tile.pinned = pinned;
+    this.onChangeEmitter.fire();
+  }
+
+  /**
+   * v0.19 (#48) — handle a VS Code terminal close event. Public so tests
+   * can invoke it directly (the vscode mock's onDidCloseTerminal stub
+   * doesn't capture callbacks). Production code wires this in the
+   * constructor's onDidCloseTerminal listener.
+   *
+   * Behavior: capture pinned state BEFORE removing the tile, then if the
+   * tile was pinned, auto-clear the pin in config and fire the one-time
+   * notice. Pinning is a statement about an active terminal slot — a
+   * terminal exit therefore clears the pin so the tile lands cleanly in
+   * Closed-but-visible. For pin-across-restart, users set `autoStart: true`.
+   */
+  handleTerminalClosed(t: vscode.Terminal): void {
+    const id = this.terminalIdMap.get(t);
+    const tile = id !== undefined ? this.terminals.get(id) : undefined;
+    const cfg = tile ? this.configManager.getTerminal(tile.name) : undefined;
+    const wasPinned = cfg?.pinned === true;
+    const closedName = tile?.name;
+    const closedDisplay = tile?.displayName ?? closedName;
+    this.removeTerminal(t);
+    if (wasPinned && closedName) {
+      this.configManager.setPinned(closedName, false);
+      // v0.19 (#48) — fire onPinCleared so the UI layer (extension.ts)
+      // can show the first-auto-unpin toast. Keeping vscode.window calls
+      // out of the state machine — tracker stays a pure state machine,
+      // UI lives where the rest of the toasts do.
+      this.log(() => `pin-cleared event fired for ${closedName}`);
+      this.onPinClearedEmitter.fire({
+        name: closedName,
+        displayName: closedDisplay ?? closedName,
+      });
+    }
+    this.onChangeEmitter.fire();
+  }
+
+  /**
+   * v0.19 (#45) — attach a freshly-launched terminal synchronously so the
+   * tile is in the tracker map BEFORE the bar's next render. VS Code's
+   * `onDidOpenTerminal` event fires asynchronously after `createTerminal`
+   * returns; until it does, the registered (offline-looking) tile is what
+   * the bar renders. Calling this method from the launch path closes that
+   * gap — the live tile exists at status='idle' the instant the launch
+   * resolves, and the later `onDidOpenTerminal` is idempotent (same id via
+   * the WeakMap, same status — fired re-fire is harmless).
+   */
+  attachLaunchedTerminal(terminal: vscode.Terminal): void {
+    this.addTerminal(terminal);
+    this.startNameRefresh();
     this.onChangeEmitter.fire();
   }
 

--- a/src/terminalTracker.ts
+++ b/src/terminalTracker.ts
@@ -19,6 +19,12 @@ const STATUS_FRESH_MS = 60_000;
 // genuinely-stale counter clears within the next attention window.
 const SUBAGENT_WATCHDOG_MS = 60_000;
 
+// v0.19 (#36) — burst window for the "freshly ready" pulse. Long enough to
+// notice across a peripheral glance, short enough to fade before it becomes
+// background noise. Mirrors the audio chime as the canonical "this just
+// finished" cue.
+const FRESHLY_READY_MS = 3_000;
+
 // Status values that mean "Claude is not actively running" — suppression of
 // the registered tile doesn't apply to these. `idle` is included because a
 // fresh idle file just means the hook fired on session start/end; the slug
@@ -62,6 +68,12 @@ export class TerminalTracker implements vscode.Disposable {
   // zero the counter. Catches the in-turn fan-out case the v0.14.1 Stop-
   // reset doesn't cover (long agentic turns that never yield a parent Stop).
   private subagentWatchdogTimers = new Map<number, NodeJS.Timeout>();
+
+  // v0.19 (#36) — per-tile timer that clears the `freshlyReady` flag after
+  // FRESHLY_READY_MS. Cancelled if the tile transitions out of ready before
+  // the timer fires (avoids a spurious "fresh" pulse on a tile that already
+  // moved on).
+  private freshlyReadyTimers = new Map<number, NodeJS.Timeout>();
 
   // Focus tracking: which tile was focused while in "waiting" state
   private focusedWaitingTile: number | null = null;
@@ -568,6 +580,7 @@ export class TerminalTracker implements vscode.Disposable {
             tile.status = 'ready';
             tile.statusLabel = this.configManager.getLabel('ready');
             tile.ignoredText = undefined;
+            this.markFreshlyReady(tile);
             this.startReadyTimer(tile.id);
             changed = true;
           }
@@ -677,6 +690,7 @@ export class TerminalTracker implements vscode.Disposable {
             // the flag was stale). Clear it so it doesn't resurface if the
             // tile later cycles through working again.
             tile.subagentPermissionPending = false;
+            this.markFreshlyReady(tile);
             this.startReadyTimer(tile.id);
             changed = true;
           } else if (tile.statusLabel !== newLabel) {
@@ -863,6 +877,11 @@ export class TerminalTracker implements vscode.Disposable {
       if (changed) {
         tile.lastActivity = Date.now();
         tile.event = event;
+        // v0.19 (#36) — clear fresh-ready on transitions out of ready.
+        // Label-only refreshes (ready → ready) leave both alone.
+        if (prev === 'ready' && tile.status !== 'ready') {
+          this.clearFreshlyReady(tile);
+        }
         this.log(() => `transition ${tile.name}: ${prev} → ${tile.status} (event=${event ?? '-'})`);
         // v0.12 — emit state transition for audio + other downstream
         // consumers. Fires on every status change (not label-only refreshes).
@@ -924,6 +943,44 @@ export class TerminalTracker implements vscode.Disposable {
     if (existing) {
       clearTimeout(existing);
       this.readyTimers.delete(id);
+    }
+  }
+
+  /**
+   * v0.19 (#36) — stamp a tile as just-now-ready. Sets `readyAt` for the
+   * sort comparator (so the tile floats to the top of the ready band) and
+   * `freshlyReady` for the webview's brighter burst pulse. The flag clears
+   * after FRESHLY_READY_MS via a per-tile timer that fires `onChange` so
+   * the webview repaints.
+   */
+  private markFreshlyReady(tile: TileData): void {
+    tile.readyAt = Date.now();
+    tile.freshlyReady = true;
+    const existing = this.freshlyReadyTimers.get(tile.id);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      this.freshlyReadyTimers.delete(tile.id);
+      const live = this.terminals.get(tile.id);
+      if (!live || !live.freshlyReady) return;
+      live.freshlyReady = false;
+      this.onChangeEmitter.fire();
+    }, FRESHLY_READY_MS);
+    this.freshlyReadyTimers.set(tile.id, timer);
+  }
+
+  /**
+   * v0.19 (#36) — wipe the freshly-ready stamp + cancel the pending decay
+   * timer. Called from the central transition-out-of-ready check so working
+   * / done / error / offline transitions don't leave a stale "fresh" pulse
+   * on a tile that's no longer ready.
+   */
+  private clearFreshlyReady(tile: TileData): void {
+    tile.readyAt = undefined;
+    tile.freshlyReady = false;
+    const existing = this.freshlyReadyTimers.get(tile.id);
+    if (existing) {
+      clearTimeout(existing);
+      this.freshlyReadyTimers.delete(tile.id);
     }
   }
 
@@ -1103,6 +1160,16 @@ export class TerminalTracker implements vscode.Disposable {
       unpinned.sort((a, b) => {
         const orderDiff = (statusOrder[a.status] ?? 5) - (statusOrder[b.status] ?? 5);
         if (orderDiff !== 0) return orderDiff;
+        // v0.19 (#36) — within the ready band, sort by transition-into-ready
+        // time descending so the just-now-ready tile sits at the top. Falls
+        // back to lastActivity for tiles without readyAt (e.g. the
+        // subagentPermissionPending → ready render-only promotion above,
+        // which doesn't go through the ready-transition code path).
+        if (a.status === 'ready' && b.status === 'ready') {
+          const ar = a.readyAt ?? a.lastActivity;
+          const br = b.readyAt ?? b.lastActivity;
+          return br - ar;
+        }
         return b.lastActivity - a.lastActivity;
       });
     }
@@ -1113,14 +1180,14 @@ export class TerminalTracker implements vscode.Disposable {
     const registered = this.configManager.getShowRegisteredProjects()
       ? this.synthesizeRegisteredTiles(new Set(all.map((t) => t.name)))
       : [];
-    registered.sort((a, b) => {
-      const ao = this.configManager.getTerminal(a.name)?.order;
-      const bo = this.configManager.getTerminal(b.name)?.order;
-      if (ao !== undefined && bo !== undefined && ao !== bo) return ao - bo;
-      if (ao !== undefined && bo === undefined) return -1;
-      if (ao === undefined && bo !== undefined) return 1;
-      return a.name.localeCompare(b.name);
-    });
+    // v0.19 (#37) — strict alphabetical by displayName. Registered tiles
+    // aren't drag-reorderable in the bar (only running tiles in manual sort
+    // are), so any `order` field on a registered entry is by definition
+    // stale state from a prior session. displayName (nickname || name)
+    // matches what the user actually sees on the tile.
+    registered.sort((a, b) =>
+      a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }),
+    );
 
     return [...unpinned, ...pinned, ...registered];
   }
@@ -1245,6 +1312,10 @@ export class TerminalTracker implements vscode.Disposable {
       clearTimeout(timer);
     }
     this.subagentWatchdogTimers.clear();
+    for (const timer of this.freshlyReadyTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.freshlyReadyTimers.clear();
     for (const d of this.disposables) d.dispose();
     this.terminals.clear();
     this.terminalRefs.clear();

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,18 @@ export interface TileData {
   // has been submitted yet for this tile.
   lastPrompt?: string;
   lastPromptAt?: number;
+  // v0.19 (#36) — millisecond timestamp of the most recent transition
+  // *into* `ready`. Used by the auto-mode comparator to keep newly-ready
+  // tiles at the top of the ready band (vs. ageing-by-other-events drift
+  // when the band falls back to lastActivity). Cleared on transitions
+  // out of ready (working/done/error/offline). Undefined for tiles that
+  // were never ready or have moved on.
+  readyAt?: number;
+  // v0.19 (#36) — true for ~3s after a ready transition. Webview adds a
+  // .fresh class for a brighter / faster pulse so the user can see at a
+  // glance which tile just transitioned. Decays via a tracker timer that
+  // fires onChange when it clears.
+  freshlyReady?: boolean;
 }
 
 /**
@@ -107,6 +119,7 @@ export type WebviewMessage =
   | { type: 'showLastPrompt'; id: number }
   | { type: 'launchByName'; name: string }
   | { type: 'hideRegisteredTile'; name: string }
+  | { type: 'copyHotkeyJson'; id: number }
   // v0.12 — webview → extension acks after an audio play attempt. Only the
   // internal __firePlayForTest command consumes these; production code
   // ignores them. Kept always-on so the CI smoke test doesn't need a

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -20,6 +20,9 @@ export class EventEmitter {
 class MockUri {
   constructor(public readonly fsPath: string) {}
   static file(p: string) { return new MockUri(p); }
+  static joinPath(base: MockUri, ...segs: string[]) {
+    return new MockUri([base.fsPath, ...segs].join('/'));
+  }
 }
 
 export const Uri = MockUri;
@@ -47,6 +50,46 @@ export const window = {
     _terminals.push(t);
     return t;
   }),
+  // v0.19 — minimal WebviewPanel mock for organizer/panel lifecycle tests.
+  // Records every onDidReceiveMessage/onDidDispose listener so tests can
+  // count subscriptions across show/dispose/reopen cycles.
+  createWebviewPanel: vi.fn(() => {
+    const onDidDisposeListeners: Function[] = [];
+    const onDidReceiveMessageListeners: Function[] = [];
+    const panel = {
+      reveal: vi.fn(),
+      dispose: vi.fn(() => {
+        for (const l of onDidDisposeListeners) l();
+      }),
+      iconPath: undefined as any,
+      webview: {
+        html: '',
+        cspSource: 'vscode-webview://test',
+        asWebviewUri: (uri: any) => uri,
+        postMessage: vi.fn(() => Promise.resolve(true)),
+        onDidReceiveMessage: vi.fn((listener: Function) => {
+          onDidReceiveMessageListeners.push(listener);
+          return { dispose: () => {
+            const i = onDidReceiveMessageListeners.indexOf(listener);
+            if (i >= 0) onDidReceiveMessageListeners.splice(i, 1);
+          }};
+        }),
+      },
+      onDidDispose: vi.fn((listener: Function) => {
+        onDidDisposeListeners.push(listener);
+        return { dispose: () => {
+          const i = onDidDisposeListeners.indexOf(listener);
+          if (i >= 0) onDidDisposeListeners.splice(i, 1);
+        }};
+      }),
+      // Expose internal listener lists for tests to inspect.
+      __testListeners: () => ({
+        onDidDispose: onDidDisposeListeners,
+        onDidReceiveMessage: onDidReceiveMessageListeners,
+      }),
+    };
+    return panel;
+  }),
   showErrorMessage: vi.fn(),
   showInformationMessage: vi.fn(),
   showWarningMessage: vi.fn(),
@@ -55,9 +98,23 @@ export const window = {
   showOpenDialog: vi.fn(),
 };
 
+export enum ViewColumn { Active = -1, Beside = -2, One = 1 }
+
+// v0.19 — registerCommand stores the callback so executeCommand can
+// dispatch through it. The prior pure-spy versions broke tests that
+// exercise the command-dispatch path (e.g. organizer launchByName → launch
+// helper). Tests that don't care about dispatch still see the mocks as
+// vi.fn() with their existing call assertions intact.
+const _commandHandlers = new Map<string, Function>();
 export const commands = {
-  executeCommand: vi.fn(),
-  registerCommand: vi.fn(),
+  registerCommand: vi.fn((cmd: string, cb: Function) => {
+    _commandHandlers.set(cmd, cb);
+    return { dispose: () => _commandHandlers.delete(cmd) };
+  }),
+  executeCommand: vi.fn((cmd: string, ...args: unknown[]) => {
+    const cb = _commandHandlers.get(cmd);
+    return cb ? Promise.resolve(cb(...args)) : Promise.resolve(undefined);
+  }),
 };
 
 export const env = {
@@ -72,5 +129,6 @@ export class RelativePattern {
 export function __resetMock() {
   _terminals.length = 0;
   window.activeTerminal = undefined;
+  _commandHandlers.clear();
   vi.clearAllMocks();
 }

--- a/test/launchProject.test.ts
+++ b/test/launchProject.test.ts
@@ -152,6 +152,29 @@ describe('launchProject', () => {
       expect(calls[0].shellPath).toBeUndefined();
       expect(calls[0].shellArgs).toBeUndefined();
     });
+
+    // v0.19 (#45) — close the "offline ghost" window by attaching the
+    // freshly-launched terminal to the tracker synchronously, before VS
+    // Code's async onDidOpenTerminal event fires. The tile must render as
+    // idle (live) the instant the launch returns.
+    it('attaches the newly-launched terminal to the tracker synchronously', () => {
+      writeConfig({
+        terminals: {
+          'fresh': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+        },
+      });
+      captureCreateTerminalCalls();
+      makeCm();
+
+      // Before launch: no live tile for 'fresh'.
+      expect(tracker.getTiles().find((t) => t.name === 'fresh' && t.status !== 'registered')).toBeUndefined();
+
+      launchRegisteredProject(cm, tracker, 'fresh', noopLog);
+
+      // After launch (synchronously, no event needed): live tile with idle.
+      const tile = tracker.getTiles().find((t) => t.name === 'fresh');
+      expect(tile?.status).toBe('idle');
+    });
   });
 
   // ─── buildLaunchCandidates ──────────────────────────────────────────

--- a/test/organizer.test.ts
+++ b/test/organizer.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { ConfigManager } from '../src/configManager';
+import { TerminalTracker } from '../src/terminalTracker';
+import { OrganizerProvider } from '../src/organizerProvider';
+import { launchRegisteredProject } from '../src/launchProject';
+import { __resetMock } from './__mocks__/vscode';
+
+vi.mock('vscode', () => import('./__mocks__/vscode'));
+
+/**
+ * v0.19 (#44) — when the user drops a closed (non-live) tile into the
+ * Pinned or Auto-sort lane, the organizer panel sends `launchNames` in the
+ * applyLayout message. The provider applies the config flips AND launches
+ * each named tile via `launchRegisteredProject`. This proves the wiring.
+ */
+describe('OrganizerProvider — launch-on-drop (#44)', () => {
+  let tmpWorkspace: string;
+  let cm: ConfigManager;
+  let tracker: TerminalTracker;
+  let organizer: OrganizerProvider;
+
+  beforeEach(() => {
+    __resetMock();
+    tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'organizer-test-'));
+    (vscode.window.terminals as any).length = 0;
+    (vscode.window.createTerminal as any).mockReset();
+    (vscode.workspace as any).workspaceFolders = [
+      { uri: (vscode.Uri as any).file(tmpWorkspace), name: 'test', index: 0 },
+    ];
+  });
+
+  afterEach(() => {
+    if (organizer) organizer.dispose();
+    if (tracker) tracker.dispose();
+    if (cm) cm.dispose();
+    fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+  });
+
+  function writeConfig(config: object): void {
+    fs.writeFileSync(
+      path.join(tmpWorkspace, '.claudelike-bar.jsonc'),
+      JSON.stringify(config),
+    );
+  }
+
+  function build(): void {
+    cm = new ConfigManager(path.join(tmpWorkspace, '.claudelike-bar.jsonc'));
+    tracker = new TerminalTracker(cm, () => {});
+    organizer = new OrganizerProvider(
+      (vscode.Uri as any).file(tmpWorkspace),
+      cm,
+      tracker,
+    );
+    // Mirror extension.ts: register the launchByName command so the
+    // organizer's executeCommand dispatch resolves to a real launch.
+    vscode.commands.registerCommand('claudeDashboard.launchByName', (name: unknown) => {
+      if (typeof name !== 'string') return;
+      if (!cm.hasTerminal(name)) return;
+      launchRegisteredProject(cm, tracker, name, () => {});
+    });
+  }
+
+  function captureCreate(): { calls: any[] } {
+    const calls: any[] = [];
+    (vscode.window.createTerminal as any).mockImplementation((opts: any) => {
+      calls.push(opts);
+      const t = { name: opts?.name, sendText: vi.fn(), show: vi.fn(), dispose: vi.fn() };
+      (vscode.window.terminals as any).push(t);
+      return t;
+    });
+    return { calls };
+  }
+
+  it('launches each name in launchNames after applying the layout', () => {
+    writeConfig({
+      terminals: {
+        'fresh': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+      },
+    });
+    const { calls } = captureCreate();
+    build();
+
+    organizer.handleMessage({
+      type: 'organizer:applyLayout',
+      pinnedOrder: ['fresh'],
+      unpinnedNames: [],
+      hiddenNames: [],
+      launchNames: ['fresh'],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].name).toBe('fresh');
+    expect(cm.getTerminal('fresh')?.pinned).toBe(true);
+  });
+
+  it('applies layout but skips launches when launchNames is empty', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+      },
+    });
+    const { calls } = captureCreate();
+    build();
+
+    organizer.handleMessage({
+      type: 'organizer:applyLayout',
+      pinnedOrder: ['a'],
+      unpinnedNames: [],
+      hiddenNames: [],
+      launchNames: [],
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(cm.getTerminal('a')?.pinned).toBe(true);
+  });
+
+  it('tolerates a missing launchNames field (back-compat with older webview state)', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+      },
+    });
+    const { calls } = captureCreate();
+    build();
+
+    // No launchNames in the payload — should still apply the layout cleanly.
+    organizer.handleMessage({
+      type: 'organizer:applyLayout',
+      pinnedOrder: ['a'],
+      unpinnedNames: [],
+      hiddenNames: [],
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(cm.getTerminal('a')?.pinned).toBe(true);
+  });
+
+  it('launches multiple names in one drop (batch unhide-and-launch)', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+        'b': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+      },
+    });
+    const { calls } = captureCreate();
+    build();
+
+    organizer.handleMessage({
+      type: 'organizer:applyLayout',
+      pinnedOrder: [],
+      unpinnedNames: ['a', 'b'],
+      hiddenNames: [],
+      launchNames: ['a', 'b'],
+    });
+
+    expect(calls.map((c) => c.name).sort()).toEqual(['a', 'b']);
+  });
+
+  it('filters out non-string entries in launchNames defensively', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+      },
+    });
+    const { calls } = captureCreate();
+    build();
+
+    organizer.handleMessage({
+      type: 'organizer:applyLayout',
+      pinnedOrder: ['a'],
+      unpinnedNames: [],
+      hiddenNames: [],
+      launchNames: ['a', null, 42, { foo: 'bar' }, undefined],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].name).toBe('a');
+  });
+});
+
+// v0.19 — untested element §3 from the 0.19.0 plan: panel disposal +
+// reopen lifecycle. d7b003b tracked onDidReceiveMessage in subDisposables
+// so re-opening shouldn't accumulate orphan listeners. Prove it.
+describe('OrganizerProvider — disposal + reopen lifecycle', () => {
+  let tmpWorkspace: string;
+  let cm: ConfigManager;
+  let tracker: TerminalTracker;
+  let organizer: OrganizerProvider;
+
+  beforeEach(() => {
+    __resetMock();
+    tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'organizer-life-test-'));
+    (vscode.window.terminals as any).length = 0;
+    (vscode.window.createWebviewPanel as any).mockClear();
+    (vscode.workspace as any).workspaceFolders = [
+      { uri: (vscode.Uri as any).file(tmpWorkspace), name: 'test', index: 0 },
+    ];
+    fs.writeFileSync(path.join(tmpWorkspace, '.claudelike-bar.jsonc'), '{ "terminals": {} }');
+  });
+
+  afterEach(() => {
+    if (organizer) organizer.dispose();
+    if (tracker) tracker.dispose();
+    if (cm) cm.dispose();
+    fs.rmSync(tmpWorkspace, { recursive: true, force: true });
+  });
+
+  it('disposes subDisposables when the panel closes (re-opening starts clean)', () => {
+    cm = new ConfigManager(path.join(tmpWorkspace, '.claudelike-bar.jsonc'));
+    tracker = new TerminalTracker(cm, () => {});
+    organizer = new OrganizerProvider((vscode.Uri as any).file(tmpWorkspace), cm, tracker);
+
+    // Open #1.
+    organizer.show();
+    const panel1 = (vscode.window.createWebviewPanel as any).mock.results[0].value;
+    const listeners1 = panel1.__testListeners();
+    expect(listeners1.onDidReceiveMessage.length).toBe(1);
+
+    // Simulate user closing the panel — fires onDidDispose, which should
+    // clear all subDisposables (provider's own listener tracking).
+    panel1.dispose();
+
+    // Open #2 — fresh panel, fresh listener count. If subDisposables
+    // weren't cleared, the provider would double-subscribe to
+    // configManager.onChange / tracker.onChange from the first lifecycle.
+    organizer.show();
+    const panel2 = (vscode.window.createWebviewPanel as any).mock.results[1].value;
+    const listeners2 = panel2.__testListeners();
+    expect(listeners2.onDidReceiveMessage.length).toBe(1);
+  });
+
+  it('disposing the provider tears down the panel cleanly', () => {
+    cm = new ConfigManager(path.join(tmpWorkspace, '.claudelike-bar.jsonc'));
+    tracker = new TerminalTracker(cm, () => {});
+    organizer = new OrganizerProvider((vscode.Uri as any).file(tmpWorkspace), cm, tracker);
+
+    organizer.show();
+    const panel = (vscode.window.createWebviewPanel as any).mock.results[0].value;
+
+    organizer.dispose();
+    expect(panel.dispose).toHaveBeenCalled();
+  });
+});

--- a/test/pinned.test.ts
+++ b/test/pinned.test.ts
@@ -78,6 +78,25 @@ describe('ConfigManager.setHotkey (#34)', () => {
     cm.dispose();
   });
 
+  // v0.19 — untested element §1 from the 0.19.0 plan. The hotkey field is
+  // not explicitly emitted by `generateConfigText` but rides along through
+  // JSON.stringify of the terminals block. Prove it survives a save→read
+  // round-trip without dropping silently on the next config rewrite.
+  it('hotkey survives a save → reload round-trip through generateConfigText', () => {
+    writeConfig({
+      terminals: { 'a': { color: 'cyan', icon: null, nickname: null, autoStart: false } },
+    });
+    const cm1 = new ConfigManager(CONFIG_PATH);
+    cm1.setHotkey('a', 'ctrl+alt+a');
+    (cm1 as unknown as { save: () => void }).save();
+    cm1.dispose();
+
+    // Fresh ConfigManager re-reads the file — proves the value persisted.
+    const cm2 = new ConfigManager(CONFIG_PATH);
+    expect(cm2.getTerminal('a')?.hotkey).toBe('ctrl+alt+a');
+    cm2.dispose();
+  });
+
   it('returns false for unknown terminal', () => {
     writeConfig({ terminals: {} });
     const cm = new ConfigManager(CONFIG_PATH);
@@ -1103,6 +1122,21 @@ describe('ConfigManager.getConfirmCloseOnDrop / setConfirmCloseOnDrop (#41)', ()
     expect(onDisk).not.toContain('"confirmCloseOnDrop"');
     cm.dispose();
   });
+
+  // v0.19 — untested element §2 from the 0.19.0 plan. The setter test
+  // above covers the write half; this one covers the read-back half via a
+  // fresh ConfigManager instance reading the just-saved file.
+  it('confirmCloseOnDrop survives a save → reload round-trip', () => {
+    writeConfig({ terminals: {} });
+    const cm1 = new ConfigManager(CONFIG_PATH);
+    cm1.setConfirmCloseOnDrop(false);
+    (cm1 as unknown as { save: () => void }).save();
+    cm1.dispose();
+
+    const cm2 = new ConfigManager(CONFIG_PATH);
+    expect(cm2.getConfirmCloseOnDrop()).toBe(false);
+    cm2.dispose();
+  });
 });
 
 // v0.19 (#41) — drop-to-close: tracker disposes the live VS Code terminal
@@ -1133,6 +1167,198 @@ describe('TerminalTracker.closeTerminalByName (#41)', () => {
 
     // 'a' is in config but has no live VS Code terminal (registered only).
     expect(tracker.closeTerminalByName('a')).toBe(false);
+
+    tracker.dispose();
+    cm.dispose();
+  });
+});
+
+// v0.19 (#48) — pinned-closed policy. When a pinned tile's terminal exits,
+// the pin auto-clears (so the tile lands cleanly in Closed-but-visible)
+// and the tracker fires `onPinCleared` so the UI layer can show the
+// first-auto-unpin toast. Tracker stays free of vscode.window calls.
+describe('TerminalTracker pinned-closed policy (#48)', () => {
+  it('auto-clears pinned when the terminal for a pinned tile closes', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, pinned: true },
+      },
+    });
+    const term = addMockTerminal('a');
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    expect(cm.getTerminal('a')?.pinned).toBe(true);
+
+    // Simulate VS Code firing onDidCloseTerminal — handler is the public
+    // method so we don't need the mock to capture the listener callback.
+    tracker.handleTerminalClosed(term as unknown as any);
+
+    expect(cm.getTerminal('a')?.pinned).toBeUndefined();
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it("does not fire onPinCleared when the closed terminal wasn't pinned", () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+      },
+    });
+    const term = addMockTerminal('a');
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    const events: Array<{ name: string; displayName: string }> = [];
+    tracker.onPinCleared((evt) => events.push(evt));
+
+    tracker.handleTerminalClosed(term as unknown as any);
+
+    expect(events).toHaveLength(0);
+    expect(cm.getTerminal('a')?.pinned).toBeUndefined();
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it('fires onPinCleared with name + displayName when a pinned tile closes', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: 'Aleph', autoStart: false, pinned: true },
+      },
+    });
+    const term = addMockTerminal('a');
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    const events: Array<{ name: string; displayName: string }> = [];
+    tracker.onPinCleared((evt) => events.push(evt));
+
+    tracker.handleTerminalClosed(term as unknown as any);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ name: 'a', displayName: 'Aleph' });
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it('falls back to name as displayName when no nickname is set', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, pinned: true },
+      },
+    });
+    const term = addMockTerminal('a');
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    const events: Array<{ name: string; displayName: string }> = [];
+    tracker.onPinCleared((evt) => events.push(evt));
+
+    tracker.handleTerminalClosed(term as unknown as any);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].displayName).toBe('a');
+
+    tracker.dispose();
+    cm.dispose();
+  });
+});
+
+// v0.19 (#48) — round-trip persistence for the dismissal flag.
+describe('ConfigManager.seenPinClearedNotice persistence (#48)', () => {
+  it('reads back as true when set in config', () => {
+    writeConfig({ seenPinClearedNotice: true, terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    expect(cm.getSeenPinClearedNotice()).toBe(true);
+    cm.dispose();
+  });
+
+  it('defaults to false when absent', () => {
+    writeConfig({ terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    expect(cm.getSeenPinClearedNotice()).toBe(false);
+    cm.dispose();
+  });
+
+  it('emits the override comment when true', () => {
+    writeConfig({ terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.setSeenPinClearedNotice(true);
+    (cm as unknown as { save: () => void }).save();
+    const onDisk = fs.readFileSync(CONFIG_PATH, 'utf-8');
+    expect(onDisk).toContain('"seenPinClearedNotice": true');
+    cm.dispose();
+  });
+
+  it("does not bloat the file with the default when false", () => {
+    writeConfig({ terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.setSeenPinClearedNotice(false);
+    (cm as unknown as { save: () => void }).save();
+    const onDisk = fs.readFileSync(CONFIG_PATH, 'utf-8');
+    expect(onDisk).not.toContain('seenPinClearedNotice');
+    cm.dispose();
+  });
+});
+
+// v0.19 (#45) — attachLaunchedTerminal closes the "offline ghost" window
+// between createTerminal() and the asynchronous onDidOpenTerminal event.
+// The tile must be in the tracker map immediately so the bar's next render
+// shows the live tile (idle) instead of the registered (greyed) tile.
+describe('TerminalTracker.attachLaunchedTerminal (#45)', () => {
+  it('synchronously registers a freshly-launched terminal as a live tile', () => {
+    writeConfig({
+      terminals: { 'a': { color: 'cyan', icon: null, nickname: null, autoStart: false } },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    // Before attach: tile is in config but not in the live tracker map.
+    expect(tracker.getTiles().find((t) => t.name === 'a' && t.status !== 'registered')).toBeUndefined();
+
+    const term = { name: 'a', sendText: vi.fn(), dispose: vi.fn() };
+    (vscode.window.terminals as any[]).push(term);
+    tracker.attachLaunchedTerminal(term as unknown as any);
+
+    // After attach: tile exists with a non-registered status (idle), not offline.
+    const tile = tracker.getTiles().find((t) => t.name === 'a');
+    expect(tile).toBeDefined();
+    expect(tile?.status).toBe('idle');
+    expect(tile?.status).not.toBe('offline');
+    expect(tile?.status).not.toBe('registered');
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it('is idempotent — a follow-up onDidOpenTerminal-equivalent does not reset tile state', () => {
+    writeConfig({
+      terminals: { 'a': { color: 'cyan', icon: null, nickname: null, autoStart: false } },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    const term = { name: 'a', sendText: vi.fn(), dispose: vi.fn() };
+    (vscode.window.terminals as any[]).push(term);
+    tracker.attachLaunchedTerminal(term as unknown as any);
+
+    // Mutate the tile to a non-default status to prove the second call doesn't clobber.
+    const tile = tracker.getTiles().find((t) => t.name === 'a');
+    expect(tile).toBeDefined();
+    const trackerAny = tracker as unknown as { terminals: Map<number, any>; terminalIdMap: WeakMap<any, number> };
+    const id = trackerAny.terminalIdMap.get(term);
+    expect(id).toBeDefined();
+    trackerAny.terminals.get(id!).status = 'working';
+    trackerAny.terminals.get(id!).statusLabel = 'Working';
+
+    // Second attach: should NOT reset back to idle.
+    tracker.attachLaunchedTerminal(term as unknown as any);
+
+    const after = tracker.getTiles().find((t) => t.name === 'a');
+    expect(after?.status).toBe('working');
 
     tracker.dispose();
     cm.dispose();

--- a/test/pinned.test.ts
+++ b/test/pinned.test.ts
@@ -990,3 +990,151 @@ describe('TerminalTracker.setPinned', () => {
     cm.dispose();
   });
 });
+
+// v0.19 (#39) — live tiles must respect `hidden: true` in the bar render.
+// Pre-fix bug: `getTiles()` filtered `hidden` only for synthesized
+// registered tiles, not for live VS Code terminals — a live pinned tile
+// flipped to hidden kept rendering (just slid down the sort order).
+describe('TerminalTracker.getTiles — hidden filter on live tiles (#39)', () => {
+  it('excludes live tiles whose config has hidden: true', () => {
+    writeConfig({
+      terminals: {
+        'visible': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+        'masked':  { color: 'cyan', icon: null, nickname: null, autoStart: false, hidden: true },
+      },
+    });
+    addMockTerminal('visible');
+    addMockTerminal('masked');
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    const names = tracker.getTiles().map((t) => t.name);
+    expect(names).toContain('visible');
+    expect(names).not.toContain('masked');
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it('hidden filter responds to live applyOrganizerLayout flips', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, pinned: true, order: 0 },
+      },
+    });
+    addMockTerminal('a');
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    expect(tracker.getTiles().map((t) => t.name)).toContain('a');
+
+    // Simulate the organizer panel dragging the live pinned tile to Hidden.
+    cm.applyOrganizerLayout({ pinnedOrder: [], unpinnedNames: [], hiddenNames: ['a'] });
+    // Refresh tile-side cached flags from config (extension wires this on
+    // configManager.onChange — done here explicitly for the unit test).
+    tracker.refreshFromConfig();
+
+    expect(tracker.getTiles().map((t) => t.name)).not.toContain('a');
+
+    tracker.dispose();
+    cm.dispose();
+  });
+});
+
+// v0.19 (#40) — applyOrganizerLayout must fire onChange synchronously so
+// the bar's listener can re-render without waiting for the FS round-trip.
+// Pre-fix bug: only `scheduleSave()` was called; the FS-watcher-triggered
+// reload that normally fires onChange is suppressed by `isSaving` during
+// the save window, so listeners often missed the change entirely.
+describe('ConfigManager.applyOrganizerLayout — synchronous onChange (#40)', () => {
+  it('fires onChange immediately after the in-memory mutation', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, pinned: true, order: 0 },
+      },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    let fires = 0;
+    const sub = cm.onChange(() => { fires += 1; });
+
+    cm.applyOrganizerLayout({ pinnedOrder: [], unpinnedNames: ['a'], hiddenNames: [] });
+
+    expect(fires).toBeGreaterThanOrEqual(1);
+    expect(cm.getTerminal('a')?.pinned).toBeUndefined();
+
+    sub.dispose();
+    cm.dispose();
+  });
+});
+
+// v0.19 (#41) — confirmation preference for drop-to-close.
+describe('ConfigManager.getConfirmCloseOnDrop / setConfirmCloseOnDrop (#41)', () => {
+  it('defaults to true when the field is absent', () => {
+    writeConfig({ terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    expect(cm.getConfirmCloseOnDrop()).toBe(true);
+    cm.dispose();
+  });
+
+  it('returns false when explicitly set false ("don\'t ask again")', () => {
+    writeConfig({ confirmCloseOnDrop: false, terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    expect(cm.getConfirmCloseOnDrop()).toBe(false);
+    cm.dispose();
+  });
+
+  it('setConfirmCloseOnDrop(false) persists the override into the JSONC text', () => {
+    writeConfig({ terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.setConfirmCloseOnDrop(false);
+    // Force the debounced write through.
+    (cm as unknown as { save: () => void }).save();
+    const onDisk = fs.readFileSync(CONFIG_PATH, 'utf-8');
+    expect(onDisk).toContain('"confirmCloseOnDrop": false');
+    cm.dispose();
+  });
+
+  it("setConfirmCloseOnDrop(true) doesn't bloat the file with the default", () => {
+    writeConfig({ terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.setConfirmCloseOnDrop(true);
+    (cm as unknown as { save: () => void }).save();
+    const onDisk = fs.readFileSync(CONFIG_PATH, 'utf-8');
+    expect(onDisk).not.toContain('"confirmCloseOnDrop"');
+    cm.dispose();
+  });
+});
+
+// v0.19 (#41) — drop-to-close: tracker disposes the live VS Code terminal
+// by tile name. The organizer panel routes live-tile-into-closedVisible
+// drops here after the user confirms the modal.
+describe('TerminalTracker.closeTerminalByName (#41)', () => {
+  it('disposes the live terminal and returns true when found', () => {
+    writeConfig({
+      terminals: { 'a': { color: 'cyan', icon: null, nickname: null, autoStart: false } },
+    });
+    const term = addMockTerminal('a');
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    expect(tracker.closeTerminalByName('a')).toBe(true);
+    expect(term.dispose).toHaveBeenCalledTimes(1);
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it('returns false when no live terminal matches', () => {
+    writeConfig({
+      terminals: { 'a': { color: 'cyan', icon: null, nickname: null, autoStart: false } },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    // 'a' is in config but has no live VS Code terminal (registered only).
+    expect(tracker.closeTerminalByName('a')).toBe(false);
+
+    tracker.dispose();
+    cm.dispose();
+  });
+});

--- a/test/pinned.test.ts
+++ b/test/pinned.test.ts
@@ -90,6 +90,121 @@ describe('ConfigManager.setHidden (#27)', () => {
   });
 });
 
+describe('ConfigManager.applyOrganizerLayout (tile-organizer panel)', () => {
+  it('pins listed names with sequential order, clears prior pinned/hidden flags', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, hidden: true },
+        'b': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+        'c': { color: 'cyan', icon: null, nickname: null, autoStart: false, pinned: true, order: 9 },
+      },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.applyOrganizerLayout({
+      pinnedOrder: ['b', 'a'],
+      unpinnedNames: ['c'],
+      hiddenNames: [],
+    });
+    expect(cm.getTerminal('b')?.pinned).toBe(true);
+    expect(cm.getTerminal('b')?.order).toBe(0);
+    expect(cm.getTerminal('a')?.pinned).toBe(true);
+    expect(cm.getTerminal('a')?.hidden).toBeUndefined();
+    expect(cm.getTerminal('a')?.order).toBe(1);
+    expect(cm.getTerminal('c')?.pinned).toBeUndefined();
+    expect(cm.getTerminal('c')?.order).toBeUndefined();
+    cm.dispose();
+  });
+
+  it('hidden lane sets hidden:true and clears pinned', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, pinned: true, order: 0 },
+      },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.applyOrganizerLayout({
+      pinnedOrder: [],
+      unpinnedNames: [],
+      hiddenNames: ['a'],
+    });
+    expect(cm.getTerminal('a')?.hidden).toBe(true);
+    expect(cm.getTerminal('a')?.pinned).toBeUndefined();
+    expect(cm.getTerminal('a')?.order).toBeUndefined();
+    cm.dispose();
+  });
+
+  it('unpinned lane clears both pinned and hidden', () => {
+    writeConfig({
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, hidden: true },
+      },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.applyOrganizerLayout({
+      pinnedOrder: [],
+      unpinnedNames: ['a'],
+      hiddenNames: [],
+    });
+    expect(cm.getTerminal('a')?.pinned).toBeUndefined();
+    expect(cm.getTerminal('a')?.hidden).toBeUndefined();
+    cm.dispose();
+  });
+
+  it('ignores names that have no matching config entry (defensive)', () => {
+    writeConfig({ terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    expect(() => cm.applyOrganizerLayout({
+      pinnedOrder: ['ghost'],
+      unpinnedNames: ['phantom'],
+      hiddenNames: ['void'],
+    })).not.toThrow();
+    cm.dispose();
+  });
+
+  it('rejects reserved property names (no prototype pollution)', () => {
+    writeConfig({
+      terminals: { 'a': { color: 'cyan', icon: null, nickname: null, autoStart: false } },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.applyOrganizerLayout({
+      pinnedOrder: ['__proto__', 'constructor', 'a'],
+      unpinnedNames: ['prototype'],
+      hiddenNames: ['__proto__'],
+    });
+    // Object.prototype must not gain pinned/hidden/order.
+    expect((Object.prototype as { pinned?: unknown }).pinned).toBeUndefined();
+    expect((Object.prototype as { hidden?: unknown }).hidden).toBeUndefined();
+    expect((Object.prototype as { order?: unknown }).order).toBeUndefined();
+    // The legitimate entry still applied — pinned with order=2 because
+    // the two reserved entries ahead of it consumed indices 0 and 1.
+    expect(cm.getTerminal('a')?.pinned).toBe(true);
+    expect(cm.getTerminal('a')?.order).toBe(2);
+    cm.dispose();
+  });
+
+  it("flips sortMode to 'auto' so manual order isn't silently lost", () => {
+    writeConfig({
+      sortMode: 'manual',
+      terminals: {
+        'a': { color: 'cyan', icon: null, nickname: null, autoStart: false, order: 2 },
+        'b': { color: 'cyan', icon: null, nickname: null, autoStart: false, order: 0 },
+        'c': { color: 'cyan', icon: null, nickname: null, autoStart: false, order: 1 },
+      },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    cm.applyOrganizerLayout({
+      pinnedOrder: [],
+      unpinnedNames: ['a', 'b', 'c'],
+      hiddenNames: [],
+    });
+    expect(cm.getSortMode()).toBe('auto');
+    expect(cm.getTerminal('a')?.order).toBeUndefined();
+    expect(cm.getTerminal('b')?.order).toBeUndefined();
+    expect(cm.getTerminal('c')?.order).toBeUndefined();
+    cm.dispose();
+  });
+});
+
 describe('TerminalTracker.getTiles — pinned zone', () => {
   it('places pinned tiles at the bottom in auto sort mode, regardless of urgency', () => {
     writeConfig({

--- a/test/pinned.test.ts
+++ b/test/pinned.test.ts
@@ -65,6 +65,27 @@ describe('ConfigManager.setPinned', () => {
   });
 });
 
+describe('ConfigManager.setHotkey (#34)', () => {
+  it('writes the hotkey value when set, deletes the field when cleared', () => {
+    writeConfig({
+      terminals: { 'a': { color: 'cyan', icon: null, nickname: null, autoStart: false } },
+    });
+    const cm = new ConfigManager(CONFIG_PATH);
+    expect(cm.setHotkey('a', 'ctrl+alt+a')).toBe(true);
+    expect(cm.getTerminal('a')?.hotkey).toBe('ctrl+alt+a');
+    expect(cm.setHotkey('a', null)).toBe(true);
+    expect(cm.getTerminal('a')?.hotkey).toBeUndefined();
+    cm.dispose();
+  });
+
+  it('returns false for unknown terminal', () => {
+    writeConfig({ terminals: {} });
+    const cm = new ConfigManager(CONFIG_PATH);
+    expect(cm.setHotkey('nope', 'ctrl+alt+a')).toBe(false);
+    cm.dispose();
+  });
+});
+
 describe('ConfigManager.setHidden (#27)', () => {
   it('writes hidden: true when set', () => {
     writeConfig({ terminals: { 'a': { color: 'cyan', icon: null, nickname: null, autoStart: false } } });
@@ -368,6 +389,83 @@ describe('TerminalTracker.getTiles — registered (offline) tiles (#15)', () => 
     const order = tracker.getTiles().map((t) => t.name);
     // live first (unpinned), pinned next, registered last
     expect(order).toEqual(['live', 'pinned-one', 'reg-one']);
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it('sorts registered tiles alphabetically by displayName, ignoring stale order field (#37)', () => {
+    writeConfig({
+      terminals: {
+        'zebra':       { color: 'cyan', icon: null, nickname: null, autoStart: false, order: 0 },
+        'alpha-proj':  { color: 'cyan', icon: null, nickname: 'Aardvark', autoStart: false },
+        'middle':      { color: 'cyan', icon: null, nickname: null, autoStart: false, order: 99 },
+      },
+    });
+    // No live VS Code terminals — all three synthesize as registered tiles.
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    const order = tracker.getTiles().map((t) => t.displayName);
+    // Aardvark (nickname for alpha-proj) → middle → zebra; the stale
+    // `order: 0` on zebra MUST NOT float it to the top.
+    expect(order).toEqual(['Aardvark', 'middle', 'zebra']);
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it('newly-ready tile floats to the top of the ready band (#36)', () => {
+    writeConfig({
+      sortMode: 'auto',
+      terminals: {
+        'old-ready': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+        'new-ready': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+      },
+    });
+    addMockTerminal('old-ready');
+    addMockTerminal('new-ready');
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    tracker.updateStatus('old-ready', 'working', 'PreToolUse');
+    tracker.updateStatus('old-ready', 'ready', 'Stop');
+    // Tiny gap so readyAt timestamps differ.
+    const oldReadyAt = tracker.getTiles().find((t) => t.name === 'old-ready')?.readyAt;
+    expect(typeof oldReadyAt).toBe('number');
+    // Force a later timestamp on new-ready by setting Date.now offset.
+    const realNow = Date.now;
+    const offset = (oldReadyAt as number) + 1000;
+    Date.now = () => offset;
+    tracker.updateStatus('new-ready', 'working', 'PreToolUse');
+    tracker.updateStatus('new-ready', 'ready', 'Stop');
+    Date.now = realNow;
+
+    const readyOrder = tracker.getTiles()
+      .filter((t) => t.status === 'ready')
+      .map((t) => t.name);
+    expect(readyOrder).toEqual(['new-ready', 'old-ready']);
+
+    tracker.dispose();
+    cm.dispose();
+  });
+
+  it('freshlyReady is set on ready transition and clears when transitioning out (#36)', () => {
+    writeConfig({
+      terminals: { 'p': { color: 'cyan', icon: null, nickname: null, autoStart: false } },
+    });
+    addMockTerminal('p');
+    const cm = new ConfigManager(CONFIG_PATH);
+    const tracker = new TerminalTracker(cm);
+
+    tracker.updateStatus('p', 'working', 'PreToolUse');
+    tracker.updateStatus('p', 'ready', 'Stop');
+    expect(tracker.getTiles().find((t) => t.name === 'p')?.freshlyReady).toBe(true);
+
+    // Transition out of ready clears the flag.
+    tracker.updateStatus('p', 'working', 'PreToolUse');
+    expect(tracker.getTiles().find((t) => t.name === 'p')?.freshlyReady).toBe(false);
+    expect(tracker.getTiles().find((t) => t.name === 'p')?.readyAt).toBeUndefined();
 
     tracker.dispose();
     cm.dispose();

--- a/test/terminalTracker.test.ts
+++ b/test/terminalTracker.test.ts
@@ -952,3 +952,83 @@ describe('TerminalTracker v0.9.1 — session / tool-failure / compaction', () =>
     expect(getTile()?.compacting).toBe(false);
   });
 });
+
+describe('TerminalTracker.forEachTrackedTerminal (#55)', () => {
+  let tracker: TerminalTracker;
+  let config: ConfigManager;
+
+  beforeEach(() => {
+    __resetMock();
+    writeConfig({ terminals: {} });
+  });
+
+  afterEach(() => {
+    tracker.dispose();
+    config.dispose();
+    cleanConfig();
+  });
+
+  it('iterates every live terminal and yields (terminal, tile) pairs', () => {
+    addMockTerminal('alpha');
+    addMockTerminal('beta');
+    addMockTerminal('gamma');
+    config = new ConfigManager(CONFIG_PATH);
+    tracker = new TerminalTracker(config);
+
+    const seen: string[] = [];
+    tracker.forEachTrackedTerminal((term, tile) => {
+      expect(tile.name).toBe(term.name);
+      seen.push(tile.name);
+    });
+    expect(seen.sort()).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it("skips hidden tiles — the issue's opt-out gesture", () => {
+    writeConfig({
+      terminals: {
+        'visible': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+        'hidden':  { color: 'cyan', icon: null, nickname: null, autoStart: false, hidden: true },
+      },
+    });
+    addMockTerminal('visible');
+    addMockTerminal('hidden');
+    config = new ConfigManager(CONFIG_PATH);
+    tracker = new TerminalTracker(config);
+
+    const seen: string[] = [];
+    tracker.forEachTrackedTerminal((_t, tile) => seen.push(tile.name));
+    expect(seen).toEqual(['visible']);
+  });
+
+  it('skips terminals with exitStatus set (process died, tab still open)', () => {
+    addMockTerminal('alive');
+    const dead = addMockTerminal('dead');
+    (dead as any).exitStatus = { code: 0 };
+    config = new ConfigManager(CONFIG_PATH);
+    tracker = new TerminalTracker(config);
+
+    const seen: string[] = [];
+    tracker.forEachTrackedTerminal((_term, tile) => seen.push(tile.name));
+    expect(seen).toEqual(['alive']);
+    // Sanity: the dead terminal is still tracked, just filtered out here.
+    expect(tracker.getTiles().some((t) => t.name === 'dead')).toBe(true);
+  });
+
+  it('includes shell-type tiles by default — user opted in by registering them', () => {
+    writeConfig({
+      terminals: {
+        'claude-tile': { color: 'cyan', icon: null, nickname: null, autoStart: false },
+        'shell-tile':  { color: 'cyan', icon: null, nickname: null, autoStart: false, type: 'shell' },
+      },
+    });
+    addMockTerminal('claude-tile');
+    addMockTerminal('shell-tile');
+    config = new ConfigManager(CONFIG_PATH);
+    tracker = new TerminalTracker(config);
+
+    const seen = new Map<string, string>();
+    tracker.forEachTrackedTerminal((_t, tile) => seen.set(tile.name, tile.status));
+    expect(seen.size).toBe(2);
+    expect(seen.get('shell-tile')).toBe('shell');
+  });
+});

--- a/test/webview-syntax.test.ts
+++ b/test/webview-syntax.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -21,5 +21,102 @@ describe('webview.js syntax guard', () => {
     const file = path.resolve(__dirname, '../media/webview.js');
     const source = fs.readFileSync(file, 'utf8');
     expect(() => new Function(source)).not.toThrow();
+  });
+
+  // v0.19 — organizer panel webview. Same syntax-guard rationale: a stray
+  // duplicate `const`, missing brace, or unterminated string in this file
+  // would never fail any unit test (vitest runs in Node, organizer.js
+  // runs in the webview), but would break the panel at runtime.
+  it('media/organizer.js parses without syntax errors', () => {
+    const file = path.resolve(__dirname, '../media/organizer.js');
+    const source = fs.readFileSync(file, 'utf8');
+    expect(() => new Function(source)).not.toThrow();
+  });
+});
+
+/**
+ * v0.19 (#49) — drop-preview footer copy is a pure function so its truth
+ * table is the spec. The webview IIFE exposes it as
+ * `globalThis.__organizerDropPreview` for testability — that's the only
+ * escape hatch from the wrapping closure.
+ */
+describe('organizer.js dropPreview (#49)', () => {
+  let dropPreview: (src: string, dst: string, isLive: boolean, name: string) => string | null;
+
+  beforeAll(() => {
+    const file = path.resolve(__dirname, '../media/organizer.js');
+    const source = fs.readFileSync(file, 'utf8');
+    // Stub the webview-only globals so the IIFE evaluates cleanly under Node.
+    const stub = `
+      const acquireVsCodeApi = () => ({ postMessage: () => {} });
+      const document = {
+        querySelector: () => null,
+        querySelectorAll: () => [],
+        getElementById: () => null,
+        createElement: () => ({
+          appendChild: () => {},
+          classList: { add: () => {}, remove: () => {}, contains: () => false },
+          addEventListener: () => {},
+          setAttribute: () => {},
+          dataset: {},
+          style: { setProperty: () => {} },
+        }),
+      };
+      const window = { addEventListener: () => {} };
+      ${source}
+    `;
+    new Function(stub)();
+    dropPreview = (globalThis as any).__organizerDropPreview;
+  });
+
+  it('returns null for same-lane drops', () => {
+    expect(dropPreview('pinned', 'pinned', true, 'foo')).toBe(null);
+    expect(dropPreview('auto', 'auto', true, 'foo')).toBe(null);
+  });
+
+  it('closed → pinned reads as Launch + pin', () => {
+    expect(dropPreview('closedVisible', 'pinned', false, 'foo')).toBe('Launch + pin foo');
+  });
+
+  it('closed → auto reads as Launch', () => {
+    expect(dropPreview('closedVisible', 'auto', false, 'foo')).toBe('Launch foo');
+  });
+
+  it('live → closedVisible reads as Close', () => {
+    expect(dropPreview('auto', 'closedVisible', true, 'foo')).toBe('Close foo');
+    expect(dropPreview('pinned', 'closedVisible', true, 'foo')).toBe('Close foo');
+  });
+
+  it('any → hidden reads as Hide', () => {
+    expect(dropPreview('auto', 'hidden', true, 'foo')).toBe('Hide foo');
+    expect(dropPreview('pinned', 'hidden', true, 'foo')).toBe('Hide foo');
+    expect(dropPreview('closedVisible', 'hidden', false, 'foo')).toBe('Hide foo');
+  });
+
+  it('hidden → auto reads as Unhide (and Unhide + launch when closed)', () => {
+    expect(dropPreview('hidden', 'auto', true, 'foo')).toBe('Unhide foo');
+    expect(dropPreview('hidden', 'auto', false, 'foo')).toBe('Unhide + launch foo');
+  });
+
+  it('hidden → pinned reads as Unhide + pin (and Unhide + launch + pin when closed)', () => {
+    expect(dropPreview('hidden', 'pinned', true, 'foo')).toBe('Unhide + pin foo');
+    expect(dropPreview('hidden', 'pinned', false, 'foo')).toBe('Unhide + launch + pin foo');
+  });
+
+  it('pinned → auto reads as Unpin', () => {
+    expect(dropPreview('pinned', 'auto', true, 'foo')).toBe('Unpin foo');
+  });
+
+  it('pinned → closedVisible for a NON-live tile reads as Unpin (not Close)', () => {
+    // Edge case: pinned+closed tile exists only briefly between exit
+    // and auto-unpin, but if a panel state push catches it mid-flight,
+    // moving it to CBV should drop the pin, not pretend to close.
+    expect(dropPreview('pinned', 'closedVisible', false, 'foo')).toBe('Unpin foo');
+  });
+
+  it('returns null for malformed input', () => {
+    expect(dropPreview('', 'pinned', true, 'foo')).toBe(null);
+    expect(dropPreview('auto', '', true, 'foo')).toBe(null);
+    expect(dropPreview('auto', 'pinned', true, '')).toBe(null);
   });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,6 +6,7 @@
   "assets": {
     "directory": "./public",
     "binding": "ASSETS",
-    "not_found_handling": "single-page-application"
+    "run_worker_first": true,
+    "not_found_handling": "404-page"
   }
 }


### PR DESCRIPTION
Closes #55.

## Summary

New palette command **`Claudelike Bar: Broadcast to All Tracked Terminals`** — prompts for text and fans it out to every live, non-hidden tile in this window via `terminal.sendText(text, true)`. Built for the "I just upgraded the claude CLI and need to `/compress fast` across 30 sessions" workflow that motivated #55.

## What's in this PR

- **`TerminalTracker.forEachTrackedTerminal(cb)`** helper. Skips hidden tiles (the issue's stated opt-out gesture: "mark it hidden or close it first"), terminals with `exitStatus` set (process died, tab still open), and synthesized registered tiles (no live `vscode.Terminal`).
- **Per-tile try/catch** so one bad pty doesn't abort the batch.
- **Per-state tally** (`27 ready, 3 working, 1 shell`) written to the "Claudelike Bar" output channel and surfaced in the success toast. Compensates for v1 deliberately having no filter UI — user sees exactly which tile states got hit and can decide if anything queued into a `working` tile needs a re-broadcast.
- **Last-used input remembered** via `globalState` (matches CLB's user-global config philosophy).
- **Single-window scope only in v1.** `vscode.window.terminals` is window-local; CLB's tracker mirrors it. The toast wording says "in this window" to set expectations. Cross-window fan-out via a file-based broadcast bus is deferred to a v1.5 follow-up.
- **4 new unit tests** in `test/terminalTracker.test.ts` covering live iteration, hidden filter, exitStatus filter, and shell-tile inclusion. All 470 tests pass.

## Stacked-PR note

This PR is stacked on top of #35 — its current diff shows 5 commits because PR #35's organizer work is still unmerged on `main`. The 4 leading commits (`d2f6023`, `c730c1d`, `d7b003b`, `d61e16e` per their SHAs upstream of `feature/broadcast-tracked-terminals`) belong to #35 / its follow-ups and shouldn't be reviewed here. Only `feat(0.20.0): #55 — broadcast palette command for all tracked terminals` is new in this PR. **Once #35 merges, GitHub will auto-narrow this diff to just the broadcast commit.**

## Test plan

- [ ] Install the `claudelike-bar-0.20.0.vsix` build, reload window.
- [ ] Open the palette → `Claudelike Bar: Broadcast to All Tracked Terminals` appears.
- [ ] With 2-3 mixed terminals open (claude + shell), broadcast `echo broadcast-test` → all terminals echo the string; toast says "Broadcast sent to N terminals in this window (N ready)".
- [ ] Mark one tile `hidden: true` in `~/.claude/claudelike-bar.jsonc`, re-broadcast → hidden tile is NOT hit; count drops by 1.
- [ ] Close a terminal (process exits but tab stays); re-broadcast → dead tile skipped; count drops.
- [ ] Re-open the palette → InputBox pre-populates with the last-used text.
- [ ] Output channel ("Claudelike Bar") shows per-broadcast trace line with per-state breakdown.
- [ ] Empty input → silently cancels, no toast.
- [ ] No live tiles → toast says "no tracked terminals to broadcast to."

🤖 Generated with [Claude Code](https://claude.com/claude-code)